### PR TITLE
Add email notifications for reservation lifecycle

### DIFF
--- a/app/Jobs/ExpireReservationJob.php
+++ b/app/Jobs/ExpireReservationJob.php
@@ -3,6 +3,7 @@
 namespace App\Jobs;
 
 use App\Models\Reservation;
+use App\Notifications\ReservationExpiredNotification;
 use App\Repositories\ReservationRepository;
 use App\Services\PaymentService;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -28,6 +29,10 @@ class ExpireReservationJob implements ShouldQueue
 
         if ($payment) {
             $paymentService->cancelPaymentIntent($payment);
+        }
+
+        if ($reservation->user) {
+            $reservation->user->notify(new ReservationExpiredNotification($reservation));
         }
     }
 }

--- a/app/Jobs/SendReservationRemindersJob.php
+++ b/app/Jobs/SendReservationRemindersJob.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Notifications\ReservationReminderNotification;
+use App\Repositories\ReservationRepository;
+use App\Repositories\RestaurantSettingRepository;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class SendReservationRemindersJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function handle(
+        RestaurantSettingRepository $settingRepository,
+        ReservationRepository $reservationRepository,
+    ): void {
+        $reminderHours = $settingRepository->get()->reminder_hours_before;
+        $reservations = $reservationRepository->findDueForReminder($reminderHours);
+
+        foreach ($reservations as $reservation) {
+            if (! $reservation->user) {
+                continue;
+            }
+
+            $reservation->user->notify(new ReservationReminderNotification($reservation));
+            $reservation->update(['reminder_sent_at' => now()]);
+        }
+    }
+}

--- a/app/Models/Reservation.php
+++ b/app/Models/Reservation.php
@@ -26,6 +26,7 @@ class Reservation extends Model
         'end_time',
         'status',
         'expires_at',
+        'reminder_sent_at',
     ];
 
     protected function casts(): array
@@ -33,6 +34,7 @@ class Reservation extends Model
         return [
             'date' => 'date',
             'expires_at' => 'datetime',
+            'reminder_sent_at' => 'datetime',
         ];
     }
 

--- a/app/Models/RestaurantSetting.php
+++ b/app/Models/RestaurantSetting.php
@@ -12,6 +12,7 @@ class RestaurantSetting extends Model
         'refund_percentage',
         'admin_fee_percentage',
         'default_reservation_duration_minutes',
+        'reminder_hours_before',
     ];
 
     protected function casts(): array

--- a/app/Notifications/ReservationCancelledNotification.php
+++ b/app/Notifications/ReservationCancelledNotification.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Reservation;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class ReservationCancelledNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(
+        private Reservation $reservation,
+        private ?float $refundAmount = null,
+    ) {
+    }
+
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        $this->reservation->loadMissing('table');
+        $reservation = $this->reservation;
+        /** @var \App\Models\Table $table */
+        $table = $reservation->table;
+
+        $mail = (new MailMessage())
+            ->subject('Reserva cancelada')
+            ->greeting("Hola, {$notifiable->name}!")
+            ->line('Tu reserva ha sido cancelada.')
+            ->line("Mesa: {$table->name}")
+            ->line("Fecha: {$reservation->date->format('d/m/Y')}")
+            ->line("Hora: {$reservation->start_time} - {$reservation->end_time}");
+
+        if ($this->refundAmount !== null) {
+            $formatted = number_format($this->refundAmount, 2, ',', '.');
+            $mail->line("Se ha procesado un reembolso de {$formatted} EUR.");
+        }
+
+        return $mail;
+    }
+}

--- a/app/Notifications/ReservationConfirmedNotification.php
+++ b/app/Notifications/ReservationConfirmedNotification.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Reservation;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class ReservationConfirmedNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(private Reservation $reservation)
+    {
+    }
+
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        $this->reservation->loadMissing(['table', 'cancellationPolicySnapshot']);
+        $reservation = $this->reservation;
+        /** @var \App\Models\Table $table */
+        $table = $reservation->table;
+        /** @var \App\Models\CancellationPolicySnapshot $policy */
+        $policy = $reservation->cancellationPolicySnapshot;
+
+        return (new MailMessage())
+            ->subject('Reserva confirmada')
+            ->greeting("Hola, {$notifiable->name}!")
+            ->line('Tu reserva ha sido confirmada exitosamente.')
+            ->line("Mesa: {$table->name}")
+            ->line("Fecha: {$reservation->date->format('d/m/Y')}")
+            ->line("Hora: {$reservation->start_time} - {$reservation->end_time}")
+            ->line("Comensales: {$reservation->seats_requested}")
+            ->line('---')
+            ->line('Politica de cancelacion:')
+            ->line("- Si cancelas con mas de {$policy->cancellation_deadline_hours} horas de antelacion, recibiras un reembolso completo.")
+            ->line("- Si cancelas con menos de {$policy->cancellation_deadline_hours} horas de antelacion, recibiras un reembolso del {$policy->refund_percentage}% (se aplica un cargo administrativo del {$policy->admin_fee_percentage}%).")
+            ->line('Te esperamos!');
+    }
+}

--- a/app/Notifications/ReservationExpiredNotification.php
+++ b/app/Notifications/ReservationExpiredNotification.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Reservation;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class ReservationExpiredNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(private Reservation $reservation)
+    {
+    }
+
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        $this->reservation->loadMissing('table');
+        $reservation = $this->reservation;
+        /** @var \App\Models\Table $table */
+        $table = $reservation->table;
+
+        return (new MailMessage())
+            ->subject('Reserva expirada')
+            ->greeting("Hola, {$notifiable->name}!")
+            ->line('Tu reserva ha expirado porque no se completo el pago a tiempo.')
+            ->line("Mesa: {$table->name}")
+            ->line("Fecha: {$reservation->date->format('d/m/Y')}")
+            ->line("Hora: {$reservation->start_time} - {$reservation->end_time}")
+            ->line('Si deseas, puedes realizar una nueva reserva.');
+    }
+}

--- a/app/Notifications/ReservationReminderNotification.php
+++ b/app/Notifications/ReservationReminderNotification.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Reservation;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class ReservationReminderNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(private Reservation $reservation)
+    {
+    }
+
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        $this->reservation->loadMissing('table');
+        $reservation = $this->reservation;
+        /** @var \App\Models\Table $table */
+        $table = $reservation->table;
+
+        return (new MailMessage())
+            ->subject('Recordatorio de reserva')
+            ->greeting("Hola, {$notifiable->name}!")
+            ->line('Te recordamos que tienes una reserva proxima.')
+            ->line("Mesa: {$table->name}")
+            ->line("Fecha: {$reservation->date->format('d/m/Y')}")
+            ->line("Hora: {$reservation->start_time} - {$reservation->end_time}")
+            ->line("Comensales: {$reservation->seats_requested}")
+            ->line('Te esperamos!');
+    }
+}

--- a/app/Repositories/ReservationRepository.php
+++ b/app/Repositories/ReservationRepository.php
@@ -4,6 +4,7 @@ namespace App\Repositories;
 
 use App\Models\CancellationPolicySnapshot;
 use App\Models\Reservation;
+use Carbon\Carbon;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Eloquent\Collection;
 
@@ -67,5 +68,28 @@ class ReservationRepository
         $reservation->update(['status' => $status]);
 
         return $reservation;
+    }
+
+    public function findDueForReminder(int $reminderHours): Collection
+    {
+        $now = now();
+        $windowEnd = $now->copy()->addHours($reminderHours);
+
+        return Reservation::where('status', Reservation::STATUS_CONFIRMED)
+            ->whereNull('reminder_sent_at')
+            ->whereRaw(
+                'CAST(date AS timestamp) + start_time <= ?',
+                [$windowEnd]
+            )
+            ->whereRaw(
+                'CAST(date AS timestamp) + start_time > ?',
+                [$now]
+            )
+            ->whereRaw(
+                'created_at <= (CAST(date AS timestamp) + start_time) - make_interval(hours => ?)',
+                [$reminderHours]
+            )
+            ->with(['user', 'table'])
+            ->get();
     }
 }

--- a/app/Services/ReservationService.php
+++ b/app/Services/ReservationService.php
@@ -4,6 +4,9 @@ namespace App\Services;
 
 use App\DTOs\HoldReservationDTO;
 use App\Jobs\ExpireReservationJob;
+use App\Notifications\ReservationCancelledNotification;
+use App\Notifications\ReservationConfirmedNotification;
+use App\Models\Payment;
 use App\Models\Reservation;
 use App\Models\Table;
 use App\Repositories\ReservationRepository;
@@ -123,7 +126,13 @@ class ReservationService
 
         $this->reservationRepository->updateStatus($reservation, Reservation::STATUS_CONFIRMED);
 
-        return $reservation->fresh();
+        $reservation = $reservation->fresh();
+
+        if ($reservation->user) {
+            $reservation->user->notify(new ReservationConfirmedNotification($reservation));
+        }
+
+        return $reservation;
     }
 
     public function cancel(Reservation $reservation): Reservation
@@ -139,22 +148,26 @@ class ReservationService
         $this->reservationRepository->updateStatus($reservation, Reservation::STATUS_CANCELLED);
 
         $payment = $reservation->payment;
+        $refundAmount = null;
 
-        if (! $payment || $payment->status !== \App\Models\Payment::STATUS_SUCCEEDED) {
-            return $reservation->fresh();
-        }
+        if ($payment && $payment->status === Payment::STATUS_SUCCEEDED) {
+            $snapshot = $reservation->cancellationPolicySnapshot;
+            $hoursUntilReservation = now()->diffInHours($reservationDateTime, false);
 
-        $snapshot = $reservation->cancellationPolicySnapshot;
-        $hoursUntilReservation = now()->diffInHours($reservationDateTime, false);
+            $refundAmount = $hoursUntilReservation >= $snapshot->cancellation_deadline_hours
+                ? (float) $payment->amount
+                : (float) $payment->amount * $snapshot->refund_percentage / 100;
 
-        if ($hoursUntilReservation >= $snapshot->cancellation_deadline_hours) {
-            $this->paymentService->refund($payment, (float) $payment->amount);
-        } else {
-            $refundAmount = (float) $payment->amount * $snapshot->refund_percentage / 100;
             $this->paymentService->refund($payment, $refundAmount);
         }
 
-        return $reservation->fresh();
+        $reservation = $reservation->fresh();
+
+        if ($reservation->user) {
+            $reservation->user->notify(new ReservationCancelledNotification($reservation, $refundAmount));
+        }
+
+        return $reservation;
     }
 
     public function find(int $id): ?Reservation

--- a/database/migrations/2026_03_16_083905_add_reminder_hours_before_to_restaurant_settings_table.php
+++ b/database/migrations/2026_03_16_083905_add_reminder_hours_before_to_restaurant_settings_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('restaurant_settings', function (Blueprint $table) {
+            $table->unsignedSmallInteger('reminder_hours_before')
+                ->default(24)
+                ->after('default_reservation_duration_minutes');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('restaurant_settings', function (Blueprint $table) {
+            $table->dropColumn('reminder_hours_before');
+        });
+    }
+};

--- a/database/migrations/2026_03_16_092734_add_reminder_sent_at_to_reservations_table.php
+++ b/database/migrations/2026_03_16_092734_add_reminder_sent_at_to_reservations_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('reservations', function (Blueprint $table) {
+            $table->timestamp('reminder_sent_at')->nullable()->after('expires_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('reservations', function (Blueprint $table) {
+            $table->dropColumn('reminder_sent_at');
+        });
+    }
+};

--- a/database/seeders/RestaurantSettingSeeder.php
+++ b/database/seeders/RestaurantSettingSeeder.php
@@ -15,6 +15,7 @@ class RestaurantSettingSeeder extends Seeder
             'refund_percentage' => 50,
             'admin_fee_percentage' => 10,
             'default_reservation_duration_minutes' => 120,
+            'reminder_hours_before' => 24,
         ]);
     }
 }

--- a/routes/console.php
+++ b/routes/console.php
@@ -1,8 +1,6 @@
 <?php
 
-use Illuminate\Foundation\Inspiring;
-use Illuminate\Support\Facades\Artisan;
+use App\Jobs\SendReservationRemindersJob;
+use Illuminate\Support\Facades\Schedule;
 
-Artisan::command('inspire', function () {
-    $this->comment(Inspiring::quote());
-})->purpose('Display an inspiring quote');
+Schedule::job(new SendReservationRemindersJob())->everyThirtyMinutes();

--- a/tests/Feature/ReservationNotificationTest.php
+++ b/tests/Feature/ReservationNotificationTest.php
@@ -1,0 +1,291 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Jobs\ExpireReservationJob;
+use App\Jobs\SendReservationRemindersJob;
+use App\Models\Payment;
+use App\Models\Reservation;
+use App\Models\Table;
+use App\Models\User;
+use App\Notifications\ReservationCancelledNotification;
+use App\Notifications\ReservationConfirmedNotification;
+use App\Notifications\ReservationExpiredNotification;
+use App\Notifications\ReservationReminderNotification;
+use App\Services\PaymentService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Mockery;
+use Mockery\MockInterface;
+use Stripe\Event;
+use Stripe\Webhook;
+use Tests\TestCase;
+
+class ReservationNotificationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private PaymentService&MockInterface $paymentServiceMock;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed(\Database\Seeders\RoleSeeder::class);
+        $this->seed(\Database\Seeders\RestaurantSettingSeeder::class);
+
+        $this->paymentServiceMock = Mockery::mock(PaymentService::class);
+        $this->app->instance(PaymentService::class, $this->paymentServiceMock);
+    }
+
+    private function clientUser(): User
+    {
+        $user = User::factory()->create();
+        $user->assignRole('client');
+
+        return $user;
+    }
+
+    private function createTable(array $overrides = []): Table
+    {
+        return Table::create(array_merge([
+            'name' => 'Mesa ' . uniqid(),
+            'min_capacity' => 2,
+            'max_capacity' => 4,
+            'location' => 'interior',
+            'is_active' => true,
+        ], $overrides));
+    }
+
+    private function createReservation(User $user, Table $table, array $overrides = []): Reservation
+    {
+        $reservation = Reservation::create(array_merge([
+            'user_id' => $user->id,
+            'table_id' => $table->id,
+            'seats_requested' => 2,
+            'date' => now()->addDays(3)->format('Y-m-d'),
+            'start_time' => '20:00:00',
+            'end_time' => '22:00:00',
+            'status' => Reservation::STATUS_CONFIRMED,
+            'expires_at' => now()->addMinutes(15),
+        ], $overrides));
+
+        $reservation->cancellationPolicySnapshot()->create([
+            'cancellation_deadline_hours' => 24,
+            'refund_percentage' => 50,
+            'admin_fee_percentage' => 10,
+            'policy_accepted_at' => now(),
+        ]);
+
+        return $reservation;
+    }
+
+    // ── Confirmation ──────────────────────────────────────────
+
+    private function webhookPayload(string $gatewayId): string
+    {
+        return json_encode([
+            'id' => 'evt_test_' . uniqid(),
+            'type' => 'payment_intent.succeeded',
+            'data' => [
+                'object' => [
+                    'id' => $gatewayId,
+                    'object' => 'payment_intent',
+                    'amount' => 1000,
+                    'currency' => 'eur',
+                    'status' => 'succeeded',
+                ],
+            ],
+        ]);
+    }
+
+    public function test_confirmed_notification_is_sent_on_payment_success(): void
+    {
+        Notification::fake();
+
+        $client = $this->clientUser();
+        $table = $this->createTable();
+        $reservation = $this->createReservation($client, $table, [
+            'status' => Reservation::STATUS_PENDING,
+        ]);
+
+        $payment = $reservation->payment()->create([
+            'amount' => 10.00,
+            'status' => Payment::STATUS_PENDING,
+            'payment_gateway_id' => 'pi_test_confirm',
+        ]);
+
+        $this->paymentServiceMock
+            ->shouldReceive('handleSucceededPayment')
+            ->with('pi_test_confirm')
+            ->once()
+            ->andReturn($payment->fresh());
+
+        $payload = $this->webhookPayload('pi_test_confirm');
+
+        $webhookMock = Mockery::mock('alias:' . Webhook::class);
+        $webhookMock->shouldReceive('constructEvent')
+            ->once()
+            ->andReturn(Event::constructFrom(json_decode($payload, true)));
+
+        $this->postJson('/api/stripe/webhook', [], [
+            'HTTP_STRIPE_SIGNATURE' => 't=123,v1=fake_signature',
+        ]);
+
+        Notification::assertSentTo($client, ReservationConfirmedNotification::class);
+    }
+
+    // ── Cancellation ──────────────────────────────────────────
+
+    public function test_cancelled_notification_is_sent_with_refund_amount(): void
+    {
+        Notification::fake();
+
+        $client = $this->clientUser();
+        $table = $this->createTable();
+        $reservation = $this->createReservation($client, $table);
+
+        $reservation->payment()->create([
+            'amount' => 10.00,
+            'status' => Payment::STATUS_SUCCEEDED,
+            'payment_gateway_id' => 'pi_test_cancel',
+            'paid_at' => now(),
+        ]);
+
+        $this->paymentServiceMock
+            ->shouldReceive('refund')
+            ->once();
+
+        $this->actingAs($client)
+            ->postJson("/api/reservations/{$reservation->id}/cancel");
+
+        Notification::assertSentTo($client, ReservationCancelledNotification::class);
+    }
+
+    public function test_cancelled_notification_is_sent_without_refund_when_no_payment(): void
+    {
+        Notification::fake();
+
+        $client = $this->clientUser();
+        $table = $this->createTable();
+        $reservation = $this->createReservation($client, $table, [
+            'status' => Reservation::STATUS_PENDING,
+        ]);
+
+        $this->paymentServiceMock->shouldNotReceive('refund');
+
+        $this->actingAs($client)
+            ->postJson("/api/reservations/{$reservation->id}/cancel");
+
+        Notification::assertSentTo($client, ReservationCancelledNotification::class);
+    }
+
+    // ── Expiration ────────────────────────────────────────────
+
+    public function test_expired_notification_is_sent_when_reservation_expires(): void
+    {
+        Notification::fake();
+
+        $client = $this->clientUser();
+        $table = $this->createTable();
+        $reservation = $this->createReservation($client, $table, [
+            'status' => Reservation::STATUS_PENDING,
+        ]);
+
+        $job = new ExpireReservationJob($reservation->id);
+        $job->handle(app(\App\Repositories\ReservationRepository::class), $this->paymentServiceMock);
+
+        Notification::assertSentTo($client, ReservationExpiredNotification::class);
+    }
+
+    public function test_expired_notification_is_sent_for_guest_reservation(): void
+    {
+        Notification::fake();
+
+        $guestUser = User::create([
+            'name' => 'Guest User',
+            'email' => 'guest@example.com',
+        ]);
+        $guestUser->assignRole('client');
+
+        $table = $this->createTable();
+        $reservation = $this->createReservation($guestUser, $table, [
+            'status' => Reservation::STATUS_PENDING,
+        ]);
+
+        $job = new ExpireReservationJob($reservation->id);
+        $job->handle(app(\App\Repositories\ReservationRepository::class), $this->paymentServiceMock);
+
+        Notification::assertSentTo($guestUser, ReservationExpiredNotification::class);
+    }
+
+    // ── Reminder ──────────────────────────────────────────────
+
+    public function test_reminder_is_sent_for_eligible_reservations(): void
+    {
+        Notification::fake();
+
+        $client = $this->clientUser();
+        $table = $this->createTable();
+
+        $reservation = $this->createReservation($client, $table, [
+            'date' => now()->addHours(12)->format('Y-m-d'),
+            'start_time' => now()->addHours(12)->format('H:i:s'),
+        ]);
+
+        $reservation->forceFill(['created_at' => now()->subDays(2)])->save();
+
+        $job = new SendReservationRemindersJob();
+        $job->handle(
+            app(\App\Repositories\RestaurantSettingRepository::class),
+            app(\App\Repositories\ReservationRepository::class),
+        );
+
+        Notification::assertSentTo($client, ReservationReminderNotification::class);
+    }
+
+    public function test_reminder_is_not_sent_for_same_day_reservations(): void
+    {
+        Notification::fake();
+
+        $client = $this->clientUser();
+        $table = $this->createTable();
+
+        $this->createReservation($client, $table, [
+            'date' => now()->addHours(12)->format('Y-m-d'),
+            'start_time' => now()->addHours(12)->format('H:i:s'),
+            'created_at' => now(),
+        ]);
+
+        $job = new SendReservationRemindersJob();
+        $job->handle(
+            app(\App\Repositories\RestaurantSettingRepository::class),
+            app(\App\Repositories\ReservationRepository::class),
+        );
+
+        Notification::assertNothingSent();
+    }
+
+    public function test_reminder_is_not_sent_twice(): void
+    {
+        Notification::fake();
+
+        $client = $this->clientUser();
+        $table = $this->createTable();
+
+        $this->createReservation($client, $table, [
+            'date' => now()->addHours(12)->format('Y-m-d'),
+            'start_time' => now()->addHours(12)->format('H:i:s'),
+            'created_at' => now()->subDays(2),
+            'reminder_sent_at' => now()->subHour(),
+        ]);
+
+        $job = new SendReservationRemindersJob();
+        $job->handle(
+            app(\App\Repositories\RestaurantSettingRepository::class),
+            app(\App\Repositories\ReservationRepository::class),
+        );
+
+        Notification::assertNothingSent();
+    }
+}


### PR DESCRIPTION
## Summary
- Add 4 queued email notifications: confirmed, cancelled, expired, reminder
- Add `reminder_hours_before` to restaurant_settings (migration + model + seeder)
- Add `reminder_sent_at` to reservations to prevent duplicate reminders
- Add `SendReservationRemindersJob` scheduled every 30 minutes
- Add `findDueForReminder()` to ReservationRepository with parameterized SQL
- Add null guards for guest reservations (user_id nullable scenario)
- Move `loadMissing()` from notification constructors to `toMail()` (queue serialization fix)
- 8 feature tests with `Notification::fake()`

## Test plan
- [x] Confirmation notification sent on payment success (via webhook)
- [x] Cancellation notification sent with refund amount
- [x] Cancellation notification sent without refund when no payment
- [x] Expiration notification sent when reservation expires
- [x] Guest reservation expiration sends notification to lazy user
- [x] Reminder sent for eligible reservations (created > 24h before)
- [x] Reminder NOT sent for same-day reservations
- [x] Reminder NOT sent twice (reminder_sent_at guard)
- [x] Full test suite passes (110 tests)

Closes #20