### PR TITLE
Add analytics endpoints (occupancy, revenue, top menu items)

### DIFF
--- a/app/DTOs/AnalyticsFilterDTO.php
+++ b/app/DTOs/AnalyticsFilterDTO.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\DTOs;
+
+readonly class AnalyticsFilterDTO
+{
+    public function __construct(
+        public ?string $date_from = null,
+        public ?string $date_to = null,
+    ) {}
+}

--- a/app/Http/Controllers/Admin/AnalyticsController.php
+++ b/app/Http/Controllers/Admin/AnalyticsController.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\DTOs\AnalyticsFilterDTO;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\AnalyticsFilterRequest;
+use App\Services\AnalyticsService;
+use Illuminate\Http\JsonResponse;
+
+class AnalyticsController extends Controller
+{
+    public function __construct(private AnalyticsService $service) {}
+
+    public function occupancy(AnalyticsFilterRequest $request): JsonResponse
+    {
+        $filter = new AnalyticsFilterDTO(...$request->validated());
+
+        return response()->json($this->service->occupancy($filter));
+    }
+
+    public function revenue(AnalyticsFilterRequest $request): JsonResponse
+    {
+        $filter = new AnalyticsFilterDTO(...$request->validated());
+
+        return response()->json($this->service->revenue($filter));
+    }
+
+    public function topMenuItems(AnalyticsFilterRequest $request): JsonResponse
+    {
+        $filter = new AnalyticsFilterDTO(...$request->validated());
+
+        return response()->json($this->service->topMenuItems($filter));
+    }
+}

--- a/app/Http/Requests/AnalyticsFilterRequest.php
+++ b/app/Http/Requests/AnalyticsFilterRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class AnalyticsFilterRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'date_from' => ['sometimes', 'date_format:Y-m-d'],
+            'date_to' => ['sometimes', 'date_format:Y-m-d', 'after_or_equal:date_from'],
+        ];
+    }
+}

--- a/app/Repositories/AnalyticsRepository.php
+++ b/app/Repositories/AnalyticsRepository.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace App\Repositories;
+
+use App\DTOs\AnalyticsFilterDTO;
+use App\Models\Payment;
+use App\Models\Reservation;
+use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+class AnalyticsRepository
+{
+    public function reservationsByStatus(AnalyticsFilterDTO $filter): Collection
+    {
+        return DB::table('reservations')
+            ->select('status', DB::raw('COUNT(*) as total'))
+            ->tap(fn ($q) => $this->applyDateFilter($q, $filter))
+            ->groupBy('status')
+            ->get();
+    }
+
+    public function occupancyByTable(AnalyticsFilterDTO $filter): Collection
+    {
+        return DB::table('reservations')
+            ->join('tables', 'reservations.table_id', '=', 'tables.id')
+            ->select(
+                'tables.name as table_name',
+                'tables.max_capacity',
+                DB::raw('COUNT(*) as total_reservations'),
+                DB::raw('AVG(reservations.seats_requested) as avg_seats'),
+            )
+            ->whereIn('reservations.status', [
+                Reservation::STATUS_CONFIRMED,
+                Reservation::STATUS_COMPLETED,
+            ])
+            ->tap(fn ($q) => $this->applyDateFilter($q, $filter, 'reservations.date'))
+            ->groupBy('tables.id', 'tables.name', 'tables.max_capacity')
+            ->orderByDesc('total_reservations')
+            ->get();
+    }
+
+    public function peakDays(AnalyticsFilterDTO $filter, int $limit = 5): Collection
+    {
+        return DB::table('reservations')
+            ->select('date', DB::raw('COUNT(*) as total_reservations'))
+            ->whereIn('status', [
+                Reservation::STATUS_CONFIRMED,
+                Reservation::STATUS_COMPLETED,
+            ])
+            ->tap(fn ($q) => $this->applyDateFilter($q, $filter))
+            ->groupBy('date')
+            ->orderByDesc('total_reservations')
+            ->limit($limit)
+            ->get();
+    }
+
+    public function peakHours(AnalyticsFilterDTO $filter, int $limit = 5): Collection
+    {
+        return DB::table('reservations')
+            ->select(
+                DB::raw('EXTRACT(HOUR FROM start_time)::integer as hour'),
+                DB::raw('COUNT(*) as total_reservations'),
+            )
+            ->whereIn('status', [
+                Reservation::STATUS_CONFIRMED,
+                Reservation::STATUS_COMPLETED,
+            ])
+            ->tap(fn ($q) => $this->applyDateFilter($q, $filter))
+            ->groupBy('hour')
+            ->orderByDesc('total_reservations')
+            ->limit($limit)
+            ->get();
+    }
+
+    public function averageSeatsPerReservation(AnalyticsFilterDTO $filter): float
+    {
+        return (float) (DB::table('reservations')
+            ->whereIn('status', [
+                Reservation::STATUS_CONFIRMED,
+                Reservation::STATUS_COMPLETED,
+            ])
+            ->tap(fn ($q) => $this->applyDateFilter($q, $filter))
+            ->avg('seats_requested') ?? 0);
+    }
+
+    public function revenueTotals(AnalyticsFilterDTO $filter): object
+    {
+        return DB::table('payments')
+            ->join('reservations', 'payments.reservation_id', '=', 'reservations.id')
+            ->select(
+                DB::raw('COALESCE(SUM(payments.amount), 0) as total_collected'),
+                DB::raw('COALESCE(SUM(payments.refund_amount), 0) as total_refunded'),
+                DB::raw('COUNT(*) as total_payments'),
+            )
+            ->whereIn('payments.status', [
+                Payment::STATUS_SUCCEEDED,
+                Payment::STATUS_REFUNDED,
+                Payment::STATUS_PARTIALLY_REFUNDED,
+            ])
+            ->tap(fn ($q) => $this->applyDateFilter($q, $filter, 'reservations.date'))
+            ->first();
+    }
+
+    public function topItemsByQuantity(AnalyticsFilterDTO $filter, int $limit = 10): Collection
+    {
+        return DB::table('reservation_items')
+            ->join('menu_items', 'reservation_items.menu_item_id', '=', 'menu_items.id')
+            ->join('reservations', 'reservation_items.reservation_id', '=', 'reservations.id')
+            ->select(
+                'menu_items.name',
+                'menu_items.category',
+                DB::raw('SUM(reservation_items.quantity) as total_quantity'),
+            )
+            ->whereIn('reservations.status', [
+                Reservation::STATUS_CONFIRMED,
+                Reservation::STATUS_COMPLETED,
+            ])
+            ->tap(fn ($q) => $this->applyDateFilter($q, $filter, 'reservations.date'))
+            ->groupBy('menu_items.id', 'menu_items.name', 'menu_items.category')
+            ->orderByDesc('total_quantity')
+            ->limit($limit)
+            ->get();
+    }
+
+    public function topItemsByRevenue(AnalyticsFilterDTO $filter, int $limit = 10): Collection
+    {
+        return DB::table('reservation_items')
+            ->join('menu_items', 'reservation_items.menu_item_id', '=', 'menu_items.id')
+            ->join('reservations', 'reservation_items.reservation_id', '=', 'reservations.id')
+            ->select(
+                'menu_items.name',
+                'menu_items.category',
+                DB::raw('SUM(reservation_items.quantity * reservation_items.unit_price) as total_revenue'),
+            )
+            ->whereIn('reservations.status', [
+                Reservation::STATUS_CONFIRMED,
+                Reservation::STATUS_COMPLETED,
+            ])
+            ->tap(fn ($q) => $this->applyDateFilter($q, $filter, 'reservations.date'))
+            ->groupBy('menu_items.id', 'menu_items.name', 'menu_items.category')
+            ->orderByDesc('total_revenue')
+            ->limit($limit)
+            ->get();
+    }
+
+    public function revenueByCategory(AnalyticsFilterDTO $filter): Collection
+    {
+        return DB::table('reservation_items')
+            ->join('menu_items', 'reservation_items.menu_item_id', '=', 'menu_items.id')
+            ->join('reservations', 'reservation_items.reservation_id', '=', 'reservations.id')
+            ->select(
+                'menu_items.category',
+                DB::raw('SUM(reservation_items.quantity) as total_quantity'),
+                DB::raw('SUM(reservation_items.quantity * reservation_items.unit_price) as total_revenue'),
+            )
+            ->whereIn('reservations.status', [
+                Reservation::STATUS_CONFIRMED,
+                Reservation::STATUS_COMPLETED,
+            ])
+            ->tap(fn ($q) => $this->applyDateFilter($q, $filter, 'reservations.date'))
+            ->groupBy('menu_items.category')
+            ->orderByDesc('total_revenue')
+            ->get();
+    }
+
+    private function applyDateFilter(Builder $query, AnalyticsFilterDTO $filter, string $column = 'date'): void
+    {
+        $query
+            ->when($filter->date_from, fn ($q, $date) => $q->where($column, '>=', $date))
+            ->when($filter->date_to, fn ($q, $date) => $q->where($column, '<=', $date));
+    }
+}

--- a/app/Services/AnalyticsService.php
+++ b/app/Services/AnalyticsService.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Services;
+
+use App\DTOs\AnalyticsFilterDTO;
+use App\Repositories\AnalyticsRepository;
+
+class AnalyticsService
+{
+    public function __construct(private AnalyticsRepository $repository) {}
+
+    public function occupancy(AnalyticsFilterDTO $filter): array
+    {
+        $byStatus = $this->repository->reservationsByStatus($filter);
+        $totalReservations = $byStatus->sum('total');
+
+        $byTable = $this->repository->occupancyByTable($filter);
+        $peakDays = $this->repository->peakDays($filter);
+        $peakHours = $this->repository->peakHours($filter);
+        $averageSeats = $this->repository->averageSeatsPerReservation($filter);
+
+        return [
+            'total_reservations' => $totalReservations,
+            'by_status' => $byStatus->pluck('total', 'status'),
+            'average_seats_per_reservation' => round($averageSeats, 1),
+            'by_table' => $byTable->map(fn ($table) => [
+                'table_name' => $table->table_name,
+                'total_reservations' => $table->total_reservations,
+                'occupancy_rate' => $table->max_capacity > 0
+                    ? round(($table->avg_seats / $table->max_capacity) * 100, 1)
+                    : 0,
+            ])->values()->toArray(),
+            'peak_days' => $peakDays->map(fn ($day) => [
+                'date' => $day->date,
+                'total_reservations' => $day->total_reservations,
+            ])->toArray(),
+            'peak_hours' => $peakHours->map(fn ($hour) => [
+                'hour' => $hour->hour,
+                'total_reservations' => $hour->total_reservations,
+            ])->toArray(),
+        ];
+    }
+
+    public function revenue(AnalyticsFilterDTO $filter): array
+    {
+        $totals = $this->repository->revenueTotals($filter);
+
+        $collected = (float) $totals->total_collected;
+        $refunded = (float) $totals->total_refunded;
+
+        return [
+            'total_collected' => round($collected, 2),
+            'total_refunded' => round($refunded, 2),
+            'net_revenue' => round($collected - $refunded, 2),
+            'total_payments' => (int) $totals->total_payments,
+            'average_deposit' => $totals->total_payments > 0
+                ? round($collected / $totals->total_payments, 2)
+                : 0,
+        ];
+    }
+
+    public function topMenuItems(AnalyticsFilterDTO $filter): array
+    {
+        $byQuantity = $this->repository->topItemsByQuantity($filter);
+        $byRevenue = $this->repository->topItemsByRevenue($filter);
+        $byCategory = $this->repository->revenueByCategory($filter);
+
+        return [
+            'top_by_quantity' => $byQuantity->map(fn ($item) => [
+                'menu_item' => $item->name,
+                'category' => $item->category,
+                'total_quantity' => (int) $item->total_quantity,
+            ])->toArray(),
+            'top_by_revenue' => $byRevenue->map(fn ($item) => [
+                'menu_item' => $item->name,
+                'category' => $item->category,
+                'total_revenue' => round((float) $item->total_revenue, 2),
+            ])->toArray(),
+            'by_category' => $byCategory->map(fn ($cat) => [
+                'category' => $cat->category,
+                'total_quantity' => (int) $cat->total_quantity,
+                'total_revenue' => round((float) $cat->total_revenue, 2),
+            ])->toArray(),
+        ];
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -12,7 +12,9 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
-        //
+        $middleware->alias([
+            'role' => \Spatie\Permission\Middleware\RoleMiddleware::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\Admin\AnalyticsController;
 use App\Http\Controllers\AuthController;
 use App\Http\Controllers\Client\MenuItemController as ClientMenuItemController;
 use App\Http\Controllers\GuestReservationController;
@@ -41,6 +42,12 @@ Route::middleware('auth:sanctum')->group(function () {
             Route::delete('/{reservationItem}', [PreOrderController::class, 'destroy']);
         });
     });
+});
+
+Route::middleware(['auth:sanctum', 'role:admin'])->prefix('admin/analytics')->group(function () {
+    Route::get('/occupancy', [AnalyticsController::class, 'occupancy']);
+    Route::get('/revenue', [AnalyticsController::class, 'revenue']);
+    Route::get('/top-menu-items', [AnalyticsController::class, 'topMenuItems']);
 });
 
 Route::post('/stripe/webhook', [StripeWebhookController::class, 'handle']);

--- a/tests/Feature/AnalyticsTest.php
+++ b/tests/Feature/AnalyticsTest.php
@@ -1,0 +1,351 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\MenuItem;
+use App\Models\Payment;
+use App\Models\Reservation;
+use App\Models\ReservationItem;
+use App\Models\Table;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AnalyticsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(\Database\Seeders\RoleSeeder::class);
+    }
+
+    private function adminUser(): User
+    {
+        $user = User::factory()->create();
+        $user->assignRole('admin');
+
+        return $user;
+    }
+
+    private function clientUser(): User
+    {
+        $user = User::factory()->create();
+        $user->assignRole('client');
+
+        return $user;
+    }
+
+    private function createTable(array $overrides = []): Table
+    {
+        return Table::create(array_merge([
+            'name' => 'Mesa ' . uniqid(),
+            'min_capacity' => 2,
+            'max_capacity' => 4,
+            'location' => 'interior',
+            'is_active' => true,
+        ], $overrides));
+    }
+
+    private function createReservation(array $overrides = []): Reservation
+    {
+        return Reservation::create(array_merge([
+            'user_id' => User::factory()->create()->id,
+            'table_id' => $this->createTable()->id,
+            'seats_requested' => 2,
+            'date' => '2026-03-15',
+            'start_time' => '20:00',
+            'end_time' => '22:00',
+            'status' => Reservation::STATUS_CONFIRMED,
+        ], $overrides));
+    }
+
+    // --- Authorization ---
+
+    public function test_unauthenticated_user_cannot_access_analytics(): void
+    {
+        $this->getJson('/api/admin/analytics/occupancy')->assertStatus(401);
+        $this->getJson('/api/admin/analytics/revenue')->assertStatus(401);
+        $this->getJson('/api/admin/analytics/top-menu-items')->assertStatus(401);
+    }
+
+    public function test_client_cannot_access_analytics(): void
+    {
+        $client = $this->clientUser();
+
+        $this->actingAs($client)->getJson('/api/admin/analytics/occupancy')->assertStatus(403);
+        $this->actingAs($client)->getJson('/api/admin/analytics/revenue')->assertStatus(403);
+        $this->actingAs($client)->getJson('/api/admin/analytics/top-menu-items')->assertStatus(403);
+    }
+
+    // --- Validation ---
+
+    public function test_invalid_date_format_returns_422(): void
+    {
+        $admin = $this->adminUser();
+
+        $this->actingAs($admin)
+            ->getJson('/api/admin/analytics/occupancy?date_from=15-03-2026')
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['date_from']);
+    }
+
+    public function test_date_to_before_date_from_returns_422(): void
+    {
+        $admin = $this->adminUser();
+
+        $this->actingAs($admin)
+            ->getJson('/api/admin/analytics/occupancy?date_from=2026-03-20&date_to=2026-03-10')
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['date_to']);
+    }
+
+    // --- Occupancy ---
+
+    public function test_occupancy_returns_correct_structure_and_values(): void
+    {
+        $table = $this->createTable(['name' => 'Mesa 1', 'max_capacity' => 4]);
+
+        $this->createReservation([
+            'table_id' => $table->id,
+            'seats_requested' => 2,
+            'status' => Reservation::STATUS_CONFIRMED,
+        ]);
+        $this->createReservation([
+            'table_id' => $table->id,
+            'seats_requested' => 4,
+            'date' => '2026-03-16',
+            'status' => Reservation::STATUS_COMPLETED,
+        ]);
+        $this->createReservation([
+            'status' => Reservation::STATUS_CANCELLED,
+        ]);
+
+        $response = $this->actingAs($this->adminUser())
+            ->getJson('/api/admin/analytics/occupancy');
+
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'total_reservations',
+                'by_status',
+                'average_seats_per_reservation',
+                'by_table',
+                'peak_days',
+                'peak_hours',
+            ]);
+
+        $data = $response->json();
+
+        $this->assertEquals(3, $data['total_reservations']);
+        $this->assertEquals(1, $data['by_status']['confirmed']);
+        $this->assertEquals(1, $data['by_status']['completed']);
+        $this->assertEquals(1, $data['by_status']['cancelled']);
+        $this->assertEquals(3.0, $data['average_seats_per_reservation']);
+    }
+
+    public function test_occupancy_with_no_data_returns_zeros(): void
+    {
+        $response = $this->actingAs($this->adminUser())
+            ->getJson('/api/admin/analytics/occupancy');
+
+        $response->assertStatus(200);
+
+        $data = $response->json();
+
+        $this->assertEquals(0, $data['total_reservations']);
+        $this->assertEquals(0.0, $data['average_seats_per_reservation']);
+        $this->assertEmpty($data['by_table']);
+        $this->assertEmpty($data['peak_days']);
+        $this->assertEmpty($data['peak_hours']);
+    }
+
+    // --- Revenue ---
+
+    public function test_revenue_returns_correct_calculations(): void
+    {
+        $reservation1 = $this->createReservation(['status' => Reservation::STATUS_CONFIRMED]);
+        $reservation2 = $this->createReservation([
+            'date' => '2026-03-16',
+            'status' => Reservation::STATUS_CANCELLED,
+        ]);
+
+        Payment::create([
+            'reservation_id' => $reservation1->id,
+            'amount' => 20.00,
+            'status' => Payment::STATUS_SUCCEEDED,
+            'refund_amount' => 0,
+            'payment_gateway_id' => 'pi_' . uniqid(),
+            'paid_at' => now(),
+        ]);
+
+        Payment::create([
+            'reservation_id' => $reservation2->id,
+            'amount' => 30.00,
+            'status' => Payment::STATUS_PARTIALLY_REFUNDED,
+            'refund_amount' => 15.00,
+            'payment_gateway_id' => 'pi_' . uniqid(),
+            'paid_at' => now(),
+        ]);
+
+        $response = $this->actingAs($this->adminUser())
+            ->getJson('/api/admin/analytics/revenue');
+
+        $response->assertStatus(200);
+
+        $data = $response->json();
+
+        $this->assertEquals(50.00, $data['total_collected']);
+        $this->assertEquals(15.00, $data['total_refunded']);
+        $this->assertEquals(35.00, $data['net_revenue']);
+        $this->assertEquals(2, $data['total_payments']);
+        $this->assertEquals(25.00, $data['average_deposit']);
+    }
+
+    public function test_revenue_with_no_payments_returns_zeros(): void
+    {
+        $response = $this->actingAs($this->adminUser())
+            ->getJson('/api/admin/analytics/revenue');
+
+        $response->assertStatus(200);
+
+        $data = $response->json();
+
+        $this->assertEquals(0, $data['total_collected']);
+        $this->assertEquals(0, $data['total_refunded']);
+        $this->assertEquals(0, $data['net_revenue']);
+        $this->assertEquals(0, $data['total_payments']);
+        $this->assertEquals(0, $data['average_deposit']);
+    }
+
+    // --- Top Menu Items ---
+
+    public function test_top_menu_items_returns_correct_ranking(): void
+    {
+        $reservation = $this->createReservation(['status' => Reservation::STATUS_CONFIRMED]);
+
+        $paella = MenuItem::factory()->create([
+            'name' => 'Paella',
+            'category' => 'principales',
+            'price' => 15.00,
+        ]);
+        $tortilla = MenuItem::factory()->create([
+            'name' => 'Tortilla',
+            'category' => 'entrantes',
+            'price' => 8.00,
+        ]);
+
+        ReservationItem::create([
+            'reservation_id' => $reservation->id,
+            'menu_item_id' => $paella->id,
+            'quantity' => 2,
+            'unit_price' => 15.00,
+        ]);
+        ReservationItem::create([
+            'reservation_id' => $reservation->id,
+            'menu_item_id' => $tortilla->id,
+            'quantity' => 5,
+            'unit_price' => 8.00,
+        ]);
+
+        $response = $this->actingAs($this->adminUser())
+            ->getJson('/api/admin/analytics/top-menu-items');
+
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'top_by_quantity',
+                'top_by_revenue',
+                'by_category',
+            ]);
+
+        $data = $response->json();
+
+        $this->assertEquals('Tortilla', $data['top_by_quantity'][0]['menu_item']);
+        $this->assertEquals(5, $data['top_by_quantity'][0]['total_quantity']);
+
+        $this->assertEquals('Tortilla', $data['top_by_revenue'][0]['menu_item']);
+        $this->assertEquals(40.00, $data['top_by_revenue'][0]['total_revenue']);
+
+        $this->assertEquals('Paella', $data['top_by_revenue'][1]['menu_item']);
+        $this->assertEquals(30.00, $data['top_by_revenue'][1]['total_revenue']);
+    }
+
+    public function test_top_menu_items_with_no_orders_returns_empty(): void
+    {
+        $response = $this->actingAs($this->adminUser())
+            ->getJson('/api/admin/analytics/top-menu-items');
+
+        $response->assertStatus(200);
+
+        $data = $response->json();
+
+        $this->assertEmpty($data['top_by_quantity']);
+        $this->assertEmpty($data['top_by_revenue']);
+        $this->assertEmpty($data['by_category']);
+    }
+
+    // --- Date Filters ---
+
+    public function test_date_filter_only_includes_reservations_in_range(): void
+    {
+        $this->createReservation([
+            'date' => '2026-03-10',
+            'seats_requested' => 2,
+            'status' => Reservation::STATUS_CONFIRMED,
+        ]);
+        $this->createReservation([
+            'date' => '2026-03-20',
+            'seats_requested' => 4,
+            'status' => Reservation::STATUS_CONFIRMED,
+        ]);
+
+        $response = $this->actingAs($this->adminUser())
+            ->getJson('/api/admin/analytics/occupancy?date_from=2026-03-18&date_to=2026-03-25');
+
+        $response->assertStatus(200);
+
+        $data = $response->json();
+
+        $this->assertEquals(1, $data['total_reservations']);
+        $this->assertEquals(1, $data['by_status']['confirmed']);
+    }
+
+    public function test_date_filter_works_on_revenue_endpoint(): void
+    {
+        $inRange = $this->createReservation([
+            'date' => '2026-03-15',
+            'status' => Reservation::STATUS_CONFIRMED,
+        ]);
+        $outOfRange = $this->createReservation([
+            'date' => '2026-03-01',
+            'status' => Reservation::STATUS_CONFIRMED,
+        ]);
+
+        Payment::create([
+            'reservation_id' => $inRange->id,
+            'amount' => 20.00,
+            'status' => Payment::STATUS_SUCCEEDED,
+            'refund_amount' => 0,
+            'payment_gateway_id' => 'pi_' . uniqid(),
+            'paid_at' => now(),
+        ]);
+        Payment::create([
+            'reservation_id' => $outOfRange->id,
+            'amount' => 50.00,
+            'status' => Payment::STATUS_SUCCEEDED,
+            'refund_amount' => 0,
+            'payment_gateway_id' => 'pi_' . uniqid(),
+            'paid_at' => now(),
+        ]);
+
+        $response = $this->actingAs($this->adminUser())
+            ->getJson('/api/admin/analytics/revenue?date_from=2026-03-10&date_to=2026-03-20');
+
+        $response->assertStatus(200);
+
+        $data = $response->json();
+
+        $this->assertEquals(20.00, $data['total_collected']);
+        $this->assertEquals(1, $data['total_payments']);
+    }
+}


### PR DESCRIPTION
## Summary
- Add 3 admin-only analytics endpoints under `/api/admin/analytics/`
- **Occupancy**: reservations by status, occupancy rate per table, average seats, peak days/hours
- **Revenue**: total collected, total refunded, net revenue, average deposit
- **Top menu items**: ranking by quantity and revenue, breakdown by category
- All endpoints support optional `date_from` / `date_to` query filters
- Register Spatie `role` middleware alias in `bootstrap/app.php`

## Test plan
- [x] 401 for unauthenticated users on all 3 endpoints
- [x] 403 for client role on all 3 endpoints
- [x] Validation: invalid date format (422), date_to before date_from (422)
- [x] Occupancy with data returns correct structure and values
- [x] Occupancy with no data returns zeros
- [x] Revenue calculates collected, refunded, net, average correctly
- [x] Revenue with no payments returns zeros
- [x] Top menu items ranks by quantity and revenue correctly
- [x] Top menu items with no orders returns empty arrays
- [x] Date filter restricts occupancy data to range
- [x] Date filter restricts revenue data to range
- [x] Full suite: 122 tests passing (no regressions)

Closes #22