### PR TITLE
Fix UpdateTableDTO null-filtering for nullable fields

### DIFF
--- a/app/DTOs/UpdateTableDTO.php
+++ b/app/DTOs/UpdateTableDTO.php
@@ -11,13 +11,28 @@ readonly class UpdateTableDTO
         public ?string $location = null,
         public ?string $description = null,
         public ?bool $is_active = null,
+        private array $presentFields = [],
     ) {}
+
+    public static function fromValidated(array $validated): self
+    {
+        return new self(
+            name: $validated['name'] ?? null,
+            min_capacity: $validated['min_capacity'] ?? null,
+            max_capacity: $validated['max_capacity'] ?? null,
+            location: $validated['location'] ?? null,
+            description: $validated['description'] ?? null,
+            is_active: $validated['is_active'] ?? null,
+            presentFields: array_keys($validated),
+        );
+    }
 
     public function toArray(): array
     {
         return array_filter(
             get_object_vars($this),
-            fn (mixed $value) => $value !== null,
+            fn (mixed $value, string $key) => $key !== 'presentFields' && in_array($key, $this->presentFields),
+            ARRAY_FILTER_USE_BOTH,
         );
     }
 }

--- a/app/Http/Controllers/Admin/TableController.php
+++ b/app/Http/Controllers/Admin/TableController.php
@@ -43,7 +43,7 @@ class TableController extends Controller
     {
         $this->authorize('update', $table);
 
-        $table = $this->service->update($table, new UpdateTableDTO(...$request->validated()));
+        $table = $this->service->update($table, UpdateTableDTO::fromValidated($request->validated()));
 
         return new TableResource($table);
     }

--- a/tests/Feature/TableTest.php
+++ b/tests/Feature/TableTest.php
@@ -147,6 +147,24 @@ class TableTest extends TestCase
             ->assertJsonValidationErrors(['max_capacity']);
     }
 
+    public function test_admin_can_clear_nullable_fields(): void
+    {
+        $table = Table::create($this->tableData(['description' => 'Mesa junto a la ventana']));
+
+        $response = $this->actingAs($this->adminUser())
+            ->putJson("/api/admin/tables/{$table->id}", [
+                'description' => null,
+            ]);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.description', null);
+
+        $this->assertDatabaseHas('tables', [
+            'id' => $table->id,
+            'description' => null,
+        ]);
+    }
+
     public function test_show_returns_404_for_nonexistent_table(): void
     {
         $response = $this->actingAs($this->adminUser())


### PR DESCRIPTION
## Summary
- Apply `presentFields` pattern to `UpdateTableDTO` (same fix already in `UpdateMenuItemDTO`)
- Add `fromValidated()` static constructor to capture which fields were sent
- Update `Admin/TableController::update()` to use `fromValidated()`
- Add test verifying that sending `description: null` clears the field

## Test plan
- [ ] New test `test_admin_can_clear_nullable_fields` passes
- [ ] All existing table tests pass
- [ ] Full test suite passes (122+ tests)

Closes #26