### PR TITLE
Standardize pagination to 6 items per page

### DIFF
--- a/app/Repositories/MenuItemRepository.php
+++ b/app/Repositories/MenuItemRepository.php
@@ -8,7 +8,7 @@ use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 
 class MenuItemRepository
 {
-    public function paginate(?MenuCategory $category = null, int $perPage = 15): LengthAwarePaginator
+    public function paginate(?MenuCategory $category = null, int $perPage = 6): LengthAwarePaginator
     {
         $query = MenuItem::query();
 
@@ -19,7 +19,7 @@ class MenuItemRepository
         return $query->paginate($perPage);
     }
 
-    public function paginateForClient(?MenuCategory $category = null, int $perPage = 15): LengthAwarePaginator
+    public function paginateForClient(?MenuCategory $category = null, int $perPage = 6): LengthAwarePaginator
     {
         $query = MenuItem::available()->inStock();
 

--- a/app/Repositories/ReservationRepository.php
+++ b/app/Repositories/ReservationRepository.php
@@ -45,14 +45,14 @@ class ReservationRepository
             ->exists();
     }
 
-    public function paginateForUser(int $userId, int $perPage = 15): LengthAwarePaginator
+    public function paginateForUser(int $userId, int $perPage = 6): LengthAwarePaginator
     {
         return Reservation::where('user_id', $userId)
             ->latest()
             ->paginate($perPage);
     }
 
-    public function paginate(int $perPage = 15): LengthAwarePaginator
+    public function paginate(int $perPage = 6): LengthAwarePaginator
     {
         return Reservation::latest()
             ->paginate($perPage);

--- a/app/Repositories/TableRepository.php
+++ b/app/Repositories/TableRepository.php
@@ -7,7 +7,7 @@ use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 
 class TableRepository
 {
-    public function paginate(int $perPage = 15): LengthAwarePaginator
+    public function paginate(int $perPage = 6): LengthAwarePaginator
     {
         return Table::paginate($perPage);
     }

--- a/app/Services/MenuItemService.php
+++ b/app/Services/MenuItemService.php
@@ -13,12 +13,12 @@ class MenuItemService
 {
     public function __construct(private MenuItemRepository $repository) {}
 
-    public function paginate(?MenuCategory $category = null, int $perPage = 15): LengthAwarePaginator
+    public function paginate(?MenuCategory $category = null, int $perPage = 6): LengthAwarePaginator
     {
         return $this->repository->paginate($category, $perPage);
     }
 
-    public function listForClient(?MenuCategory $category = null, int $perPage = 15): LengthAwarePaginator
+    public function listForClient(?MenuCategory $category = null, int $perPage = 6): LengthAwarePaginator
     {
         return $this->repository->paginateForClient($category, $perPage);
     }

--- a/app/Services/ReservationService.php
+++ b/app/Services/ReservationService.php
@@ -175,12 +175,12 @@ class ReservationService
         return $this->reservationRepository->find($id);
     }
 
-    public function listForUser(int $userId, int $perPage = 15): LengthAwarePaginator
+    public function listForUser(int $userId, int $perPage = 6): LengthAwarePaginator
     {
         return $this->reservationRepository->paginateForUser($userId, $perPage);
     }
 
-    public function listAll(int $perPage = 15): LengthAwarePaginator
+    public function listAll(int $perPage = 6): LengthAwarePaginator
     {
         return $this->reservationRepository->paginate($perPage);
     }

--- a/app/Services/TableService.php
+++ b/app/Services/TableService.php
@@ -12,7 +12,7 @@ class TableService
 {
     public function __construct(private TableRepository $repository) {}
 
-    public function paginate(int $perPage = 15): LengthAwarePaginator
+    public function paginate(int $perPage = 6): LengthAwarePaginator
     {
         return $this->repository->paginate($perPage);
     }


### PR DESCRIPTION
## Summary
- Change default `$perPage` from 15 to 6 in all repositories and services
- Affected: TableRepository, MenuItemRepository, ReservationRepository and their corresponding services

## Test plan
- [x] All 123 tests pass (425 assertions)
- [x] No tests depended on the previous page size value

Closes #30