### PR TITLE
Fix partial update validation for table capacity fields

### DIFF
--- a/app/Http/Requests/UpdateTableRequest.php
+++ b/app/Http/Requests/UpdateTableRequest.php
@@ -14,10 +14,15 @@ class UpdateTableRequest extends FormRequest
 
     public function rules(): array
     {
+        $table = $this->route('table');
+
+        $maxCapacityFloor = $this->has('min_capacity') ? 'gte:min_capacity' : "min:{$table->min_capacity}";
+        $minCapacityCeiling = $this->has('max_capacity') ? 'lte:max_capacity' : "max:{$table->max_capacity}";
+
         return [
-            'name'         => ['sometimes', 'string', 'max:100', Rule::unique('tables', 'name')->ignore($this->route('table'))],
-            'min_capacity' => ['sometimes', 'integer', 'min:1'],
-            'max_capacity' => ['sometimes', 'integer', 'gte:min_capacity'],
+            'name'         => ['sometimes', 'string', 'max:100', Rule::unique('tables', 'name')->ignore($table)],
+            'min_capacity' => ['sometimes', 'integer', 'min:1', $minCapacityCeiling],
+            'max_capacity' => ['sometimes', 'integer', $maxCapacityFloor],
             'location'     => ['sometimes', 'string', 'max:100'],
             'description'  => ['nullable', 'string', 'max:500'],
             'is_active'    => ['sometimes', 'boolean'],

--- a/tests/Feature/TableTest.php
+++ b/tests/Feature/TableTest.php
@@ -132,6 +132,32 @@ class TableTest extends TestCase
             ->assertJsonValidationErrors(['max_capacity']);
     }
 
+    public function test_partial_update_max_capacity_rejects_value_below_existing_min(): void
+    {
+        $table = Table::factory()->create(['min_capacity' => 4, 'max_capacity' => 6]);
+
+        $response = $this->actingAs($this->adminUser())
+            ->putJson("/api/admin/tables/{$table->id}", [
+                'max_capacity' => 2,
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['max_capacity']);
+    }
+
+    public function test_partial_update_min_capacity_rejects_value_above_existing_max(): void
+    {
+        $table = Table::factory()->create(['min_capacity' => 2, 'max_capacity' => 4]);
+
+        $response = $this->actingAs($this->adminUser())
+            ->putJson("/api/admin/tables/{$table->id}", [
+                'min_capacity' => 6,
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['min_capacity']);
+    }
+
     public function test_admin_can_clear_nullable_fields(): void
     {
         $table = Table::factory()->create(['description' => 'Mesa junto a la ventana']);


### PR DESCRIPTION
## Summary
- When only `max_capacity` is sent, validate against existing DB `min_capacity` instead of absent request field
- When only `min_capacity` is sent, validate against existing DB `max_capacity`
- When both fields are sent, validate them against each other (existing behavior)

## Test plan
- [x] New test: partial update of max_capacity below existing min is rejected
- [x] New test: partial update of min_capacity above existing max is rejected
- [x] Existing 128 tests continue passing
- [x] Full suite: 130 tests, 448 assertions

Closes #36