### PR TITLE
Add eager loading to prevent N+1 queries in listings

### DIFF
--- a/app/Repositories/PaymentRepository.php
+++ b/app/Repositories/PaymentRepository.php
@@ -13,7 +13,9 @@ class PaymentRepository
 
     public function findByGatewayId(string $gatewayId): ?Payment
     {
-        return Payment::where('payment_gateway_id', $gatewayId)->first();
+        return Payment::where('payment_gateway_id', $gatewayId)
+            ->with('reservation')
+            ->first();
     }
 
     public function update(Payment $payment, array $data): Payment

--- a/app/Repositories/ReservationRepository.php
+++ b/app/Repositories/ReservationRepository.php
@@ -50,13 +50,15 @@ class ReservationRepository
     public function paginateForUser(int $userId, int $perPage = 6): LengthAwarePaginator
     {
         return Reservation::where('user_id', $userId)
+            ->with(['table', 'payment'])
             ->latest()
             ->paginate($perPage);
     }
 
     public function paginate(int $perPage = 6): LengthAwarePaginator
     {
-        return Reservation::latest()
+        return Reservation::with(['table', 'payment'])
+            ->latest()
             ->paginate($perPage);
     }
 


### PR DESCRIPTION
## Summary
- Eager-load `table` and `payment` in `ReservationRepository::paginateForUser()` and `paginate()`
- Eager-load `reservation` in `PaymentRepository::findByGatewayId()`
- Reduces query count from 1+2N to 3 on reservation listings

## Test plan
- [x] Full suite: 131 tests, 450 assertions passing
- [x] No behavioral changes, only query optimization

Closes #40