### PR TITLE
Add auto-token and guest-specific confirmation email

### DIFF
--- a/app/Notifications/GuestReservationConfirmedNotification.php
+++ b/app/Notifications/GuestReservationConfirmedNotification.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Reservation;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class GuestReservationConfirmedNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(
+        private Reservation $reservation,
+        private string $token,
+    ) {}
+
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        $this->reservation->loadMissing(['table', 'cancellationPolicySnapshot']);
+        $reservation = $this->reservation;
+        /** @var \App\Models\Table $table */
+        $table = $reservation->table;
+        /** @var \App\Models\CancellationPolicySnapshot $policy */
+        $policy = $reservation->cancellationPolicySnapshot;
+
+        return (new MailMessage())
+            ->subject('Reserva confirmada')
+            ->greeting("Hola, {$notifiable->name}!")
+            ->line('Tu reserva ha sido confirmada exitosamente.')
+            ->line("Mesa: {$table->name}")
+            ->line("Fecha: {$reservation->date->format('d/m/Y')}")
+            ->line("Hora: {$reservation->start_time} - {$reservation->end_time}")
+            ->line("Comensales: {$reservation->seats_requested}")
+            ->line('---')
+            ->line('Politica de cancelacion:')
+            ->line("- Si cancelas con mas de {$policy->cancellation_deadline_hours} horas de antelacion, recibiras un reembolso completo.")
+            ->line("- Si cancelas con menos de {$policy->cancellation_deadline_hours} horas de antelacion, recibiras un reembolso del {$policy->refund_percentage}% (se aplica un cargo administrativo del {$policy->admin_fee_percentage}%).")
+            ->line('---')
+            ->line('Tu token de acceso para gestionar tu reserva:')
+            ->line($this->token)
+            ->line('Con este token puedes consultar tu reserva, hacer pre-pedidos o cancelar. Incluyelo como cabecera Authorization: Bearer {token} en tus peticiones.')
+            ->line('---')
+            ->line('Para completar tu cuenta y establecer una contrasena, usa el endpoint POST /auth/complete-account con tu token de acceso.')
+            ->line('Te esperamos!');
+    }
+}

--- a/app/Services/ReservationService.php
+++ b/app/Services/ReservationService.php
@@ -5,6 +5,7 @@ namespace App\Services;
 use App\DTOs\HoldReservationDTO;
 use App\Jobs\ExpireReservationJob;
 use App\Notifications\ReservationCancelledNotification;
+use App\Notifications\GuestReservationConfirmedNotification;
 use App\Notifications\ReservationConfirmedNotification;
 use App\Notifications\ReservationExpiredRefundNotification;
 use App\Models\Payment;
@@ -124,11 +125,9 @@ class ReservationService
         if ($reservation->status === Reservation::STATUS_EXPIRED) {
             $this->paymentService->refund($payment, (float) $payment->amount);
 
-            if ($reservation->user) {
-                $reservation->user->notify(
-                    new ReservationExpiredRefundNotification($reservation, (float) $payment->amount)
-                );
-            }
+            $reservation->user?->notify(
+                new ReservationExpiredRefundNotification($reservation, (float) $payment->amount)
+            );
 
             return $reservation;
         }
@@ -137,9 +136,18 @@ class ReservationService
 
         $reservation = $reservation->fresh();
 
-        if ($reservation->user) {
-            $reservation->user->notify(new ReservationConfirmedNotification($reservation));
+        if (! $reservation->user) {
+            return $reservation;
         }
+
+        if ($reservation->user->isGuest()) {
+            $token = $reservation->user->createToken('guest-token')->plainTextToken;
+            $reservation->user->notify(new GuestReservationConfirmedNotification($reservation, $token));
+
+            return $reservation;
+        }
+
+        $reservation->user->notify(new ReservationConfirmedNotification($reservation));
 
         return $reservation;
     }

--- a/tests/Feature/ReservationNotificationTest.php
+++ b/tests/Feature/ReservationNotificationTest.php
@@ -8,6 +8,7 @@ use App\Models\Payment;
 use App\Models\Reservation;
 use App\Models\User;
 use App\Notifications\ReservationCancelledNotification;
+use App\Notifications\GuestReservationConfirmedNotification;
 use App\Notifications\ReservationConfirmedNotification;
 use App\Notifications\ReservationExpiredNotification;
 use App\Notifications\ReservationExpiredRefundNotification;
@@ -91,6 +92,89 @@ class ReservationNotificationTest extends TestCase
         ]);
 
         Notification::assertSentTo($client, ReservationConfirmedNotification::class);
+    }
+
+    public function test_guest_confirmed_notification_is_sent_on_payment_success(): void
+    {
+        Notification::fake();
+
+        $guestUser = User::create([
+            'name' => 'Guest User',
+            'email' => 'guest@example.com',
+        ]);
+        $guestUser->assignRole('client');
+
+        $reservation = Reservation::factory()->pending()->withCancellationPolicy()->create([
+            'user_id' => $guestUser->id,
+        ]);
+
+        $payment = Payment::factory()->create([
+            'reservation_id' => $reservation->id,
+            'payment_gateway_id' => 'pi_test_guest_confirm',
+        ]);
+
+        $this->paymentServiceMock
+            ->shouldReceive('handleSucceededPayment')
+            ->with('pi_test_guest_confirm')
+            ->once()
+            ->andReturn($payment->fresh());
+
+        $payload = $this->webhookPayload('pi_test_guest_confirm');
+
+        $webhookMock = Mockery::mock('alias:' . Webhook::class);
+        $webhookMock->shouldReceive('constructEvent')
+            ->once()
+            ->andReturn(Event::constructFrom(json_decode($payload, true)));
+
+        $this->postJson('/api/stripe/webhook', [], [
+            'HTTP_STRIPE_SIGNATURE' => 't=123,v1=fake_signature',
+        ]);
+
+        Notification::assertSentTo($guestUser, GuestReservationConfirmedNotification::class);
+        Notification::assertNotSentTo($guestUser, ReservationConfirmedNotification::class);
+    }
+
+    public function test_guest_receives_api_token_after_payment_confirmation(): void
+    {
+        Notification::fake();
+
+        $guestUser = User::create([
+            'name' => 'Guest User',
+            'email' => 'guest-token@example.com',
+        ]);
+        $guestUser->assignRole('client');
+
+        $reservation = Reservation::factory()->pending()->withCancellationPolicy()->create([
+            'user_id' => $guestUser->id,
+        ]);
+
+        $payment = Payment::factory()->create([
+            'reservation_id' => $reservation->id,
+            'payment_gateway_id' => 'pi_test_guest_token',
+        ]);
+
+        $this->paymentServiceMock
+            ->shouldReceive('handleSucceededPayment')
+            ->with('pi_test_guest_token')
+            ->once()
+            ->andReturn($payment->fresh());
+
+        $payload = $this->webhookPayload('pi_test_guest_token');
+
+        $webhookMock = Mockery::mock('alias:' . Webhook::class);
+        $webhookMock->shouldReceive('constructEvent')
+            ->once()
+            ->andReturn(Event::constructFrom(json_decode($payload, true)));
+
+        $this->postJson('/api/stripe/webhook', [], [
+            'HTTP_STRIPE_SIGNATURE' => 't=123,v1=fake_signature',
+        ]);
+
+        $this->assertDatabaseHas('personal_access_tokens', [
+            'tokenable_id' => $guestUser->id,
+            'tokenable_type' => User::class,
+            'name' => 'guest-token',
+        ]);
     }
 
     // ── Cancellation ──────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Generate a Sanctum API token for guest users when payment is confirmed via Stripe webhook
- Create `GuestReservationConfirmedNotification` with token and account completion instructions
- Registered users continue receiving the existing confirmation email (no regression)
- Flatten nested if in `confirmPayment()` using nullsafe operator

## Test plan
- [x] All 133 tests pass (457 assertions)
- [x] Guest receives `GuestReservationConfirmedNotification` (not generic one)
- [x] Token created in `personal_access_tokens` for guest after payment
- [x] Registered user still receives `ReservationConfirmedNotification`

Closes #48