### PR TITLE
Handle uncaught exception in Stripe webhook

### DIFF
--- a/app/Exceptions/PaymentNotFoundException.php
+++ b/app/Exceptions/PaymentNotFoundException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Exceptions;
+
+use RuntimeException;
+
+class PaymentNotFoundException extends RuntimeException
+{
+    public function __construct(string $gatewayId)
+    {
+        parent::__construct("Payment not found for gateway ID: {$gatewayId}");
+    }
+}

--- a/app/Http/Controllers/StripeWebhookController.php
+++ b/app/Http/Controllers/StripeWebhookController.php
@@ -2,9 +2,11 @@
 
 namespace App\Http\Controllers;
 
+use App\Exceptions\PaymentNotFoundException;
 use App\Services\ReservationService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
 use Stripe\Exception\SignatureVerificationException;
 use Stripe\Webhook;
 
@@ -25,8 +27,12 @@ class StripeWebhookController extends Controller
         }
 
         if ($event->type === 'payment_intent.succeeded') {
-            $gatewayId = $event->data->object->id;
-            $this->reservationService->confirmPayment($gatewayId);
+            try {
+                $gatewayId = $event->data->object->id;
+                $this->reservationService->confirmPayment($gatewayId);
+            } catch (PaymentNotFoundException $e) {
+                Log::warning("Stripe webhook: {$e->getMessage()}");
+            }
         }
 
         return response()->json(['received' => true]);

--- a/app/Services/PaymentService.php
+++ b/app/Services/PaymentService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Exceptions\PaymentNotFoundException;
 use App\Models\Payment;
 use App\Repositories\PaymentRepository;
 use Stripe\PaymentIntent;
@@ -42,7 +43,7 @@ class PaymentService
         $payment = $this->paymentRepository->findByGatewayId($gatewayId);
 
         if (! $payment) {
-            throw new \RuntimeException("Payment not found for gateway ID: {$gatewayId}");
+            throw new PaymentNotFoundException($gatewayId);
         }
 
         if ($payment->status === Payment::STATUS_SUCCEEDED) {

--- a/tests/Feature/StripeWebhookTest.php
+++ b/tests/Feature/StripeWebhookTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use App\Models\Payment;
 use App\Models\Reservation;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Log;
 use Stripe\Event;
 use Stripe\Webhook;
 use Tests\TestCase;
@@ -32,11 +33,11 @@ class StripeWebhookTest extends TestCase
         return [$reservation, $payment];
     }
 
-    private function webhookPayload(string $gatewayId): string
+    private function webhookPayload(string $gatewayId, string $type = 'payment_intent.succeeded'): string
     {
         return json_encode([
             'id' => 'evt_test_' . uniqid(),
-            'type' => 'payment_intent.succeeded',
+            'type' => $type,
             'data' => [
                 'object' => [
                     'id' => $gatewayId,
@@ -119,5 +120,44 @@ class StripeWebhookTest extends TestCase
             'id' => $reservation->id,
             'status' => 'confirmed',
         ]);
+    }
+
+    public function test_webhook_returns_200_when_payment_not_found(): void
+    {
+        $nonExistentGatewayId = 'pi_non_existent_123';
+        $payload = $this->webhookPayload($nonExistentGatewayId);
+
+        $mock = \Mockery::mock('alias:' . Webhook::class);
+        $mock->shouldReceive('constructEvent')
+            ->once()
+            ->andReturn(Event::constructFrom(json_decode($payload, true)));
+
+        Log::shouldReceive('warning')
+            ->once()
+            ->withArgs(fn (string $message) => str_contains($message, $nonExistentGatewayId));
+
+        $response = $this->postJson('/api/stripe/webhook', [], [
+            'HTTP_STRIPE_SIGNATURE' => 't=123,v1=fake_signature',
+        ]);
+
+        $response->assertStatus(200)
+            ->assertJson(['received' => true]);
+    }
+
+    public function test_webhook_returns_200_for_unhandled_event_type(): void
+    {
+        $payload = $this->webhookPayload('pi_any_123', 'charge.refunded');
+
+        $mock = \Mockery::mock('alias:' . Webhook::class);
+        $mock->shouldReceive('constructEvent')
+            ->once()
+            ->andReturn(Event::constructFrom(json_decode($payload, true)));
+
+        $response = $this->postJson('/api/stripe/webhook', [], [
+            'HTTP_STRIPE_SIGNATURE' => 't=123,v1=fake_signature',
+        ]);
+
+        $response->assertStatus(200)
+            ->assertJson(['received' => true]);
     }
 }


### PR DESCRIPTION
## Summary

- Add `PaymentNotFoundException` domain exception for missing payments by gateway ID
- Catch `PaymentNotFoundException` in `StripeWebhookController` and log warning instead of returning 500
- Replace generic `RuntimeException` with `PaymentNotFoundException` in `PaymentService`
- Stripe always receives 200, preventing unnecessary retries

## Test plan

- [x] Webhook with valid payment confirms reservation (existing test)
- [x] Webhook with invalid signature returns 403 (existing test)
- [x] Webhook is idempotent for already confirmed reservation (existing test)
- [x] Webhook with non-existent payment returns 200 and logs warning (new test)
- [x] Webhook with unhandled event type returns 200 (new test)
- [x] Full test suite passes (135 tests, 464 assertions)

Closes #51