### PR TITLE
Add missing indexes on FK columns for PostgreSQL

### DIFF
--- a/database/migrations/2026_03_23_115620_add_missing_indexes_to_foreign_key_columns.php
+++ b/database/migrations/2026_03_23_115620_add_missing_indexes_to_foreign_key_columns.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('client_profiles', function (Blueprint $table) {
+            $table->index('user_id');
+        });
+
+        Schema::table('reservation_items', function (Blueprint $table) {
+            $table->index('menu_item_id');
+        });
+
+        Schema::table('role_has_permissions', function (Blueprint $table) {
+            $table->index('role_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('client_profiles', function (Blueprint $table) {
+            $table->dropIndex(['user_id']);
+        });
+
+        Schema::table('reservation_items', function (Blueprint $table) {
+            $table->dropIndex(['menu_item_id']);
+        });
+
+        Schema::table('role_has_permissions', function (Blueprint $table) {
+            $table->dropIndex(['role_id']);
+        });
+    }
+};


### PR DESCRIPTION
## Summary

- Add migration with indexes on 3 FK columns that lacked them in PostgreSQL
- `client_profiles.user_id` — no index, used for 1:1 profile lookup
- `reservation_items.menu_item_id` — second column in composite UNIQUE, not covered for standalone lookups
- `role_has_permissions.role_id` — second column in composite PK, not covered for standalone lookups

## Test plan

- [x] Migration runs without errors on dev database
- [x] Rollback works correctly
- [x] Full test suite passes (135 tests, 464 assertions)

Closes #53