### PR TITLE
Add ownership test for pre-order scoped binding

### DIFF
--- a/tests/Feature/PreOrderTest.php
+++ b/tests/Feature/PreOrderTest.php
@@ -366,6 +366,27 @@ class PreOrderTest extends TestCase
         $response->assertStatus(403);
     }
 
+    public function test_destroy_rejects_item_from_another_reservation(): void
+    {
+        $client = $this->clientUser();
+        $reservation = Reservation::factory()->confirmed()->create(['user_id' => $client->id]);
+        $otherReservation = Reservation::factory()->confirmed()->create(['user_id' => $client->id]);
+        $menuItem = MenuItem::factory()->create();
+
+        $item = ReservationItem::factory()->create([
+            'reservation_id' => $otherReservation->id,
+            'menu_item_id' => $menuItem->id,
+            'unit_price' => $menuItem->price,
+        ]);
+
+        $response = $this->actingAs($client)
+            ->deleteJson("/api/reservations/{$reservation->id}/pre-orders/{$item->id}");
+
+        $response->assertStatus(404);
+
+        $this->assertDatabaseHas('reservation_items', ['id' => $item->id]);
+    }
+
     public function test_unauthenticated_user_cannot_access_pre_orders(): void
     {
         $reservation = Reservation::factory()->confirmed()->create();


### PR DESCRIPTION
## Summary

- Add test verifying that `scopeBindings()` on the pre-order route prevents deleting a ReservationItem from a different Reservation
- No code changes needed — Laravel's scoped binding already handles the 404 response
- This test serves as a regression guard if `scopeBindings()` is ever removed

## Test plan

- [x] New test: delete pre-order from another reservation returns 404 and item persists
- [x] Full test suite passes (136 tests, 466 assertions)

Closes #55