### PR TITLE
Add time slot intervals and admin settings endpoint

### DIFF
--- a/app/DTOs/UpdateRestaurantSettingDTO.php
+++ b/app/DTOs/UpdateRestaurantSettingDTO.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\DTOs;
+
+readonly class UpdateRestaurantSettingDTO
+{
+    public function __construct(
+        public ?float $deposit_per_person = null,
+        public ?int $cancellation_deadline_hours = null,
+        public ?int $refund_percentage = null,
+        public ?int $admin_fee_percentage = null,
+        public ?int $default_reservation_duration_minutes = null,
+        public ?int $reminder_hours_before = null,
+        public ?int $time_slot_interval_minutes = null,
+        private array $presentFields = [],
+    ) {}
+
+    public static function fromValidated(array $validated): self
+    {
+        return new self(
+            deposit_per_person: $validated['deposit_per_person'] ?? null,
+            cancellation_deadline_hours: $validated['cancellation_deadline_hours'] ?? null,
+            refund_percentage: $validated['refund_percentage'] ?? null,
+            admin_fee_percentage: $validated['admin_fee_percentage'] ?? null,
+            default_reservation_duration_minutes: $validated['default_reservation_duration_minutes'] ?? null,
+            reminder_hours_before: $validated['reminder_hours_before'] ?? null,
+            time_slot_interval_minutes: $validated['time_slot_interval_minutes'] ?? null,
+            presentFields: array_keys($validated),
+        );
+    }
+
+    public function toArray(): array
+    {
+        return array_filter(
+            get_object_vars($this),
+            fn (mixed $value, string $key) => $key !== 'presentFields' && in_array($key, $this->presentFields),
+            ARRAY_FILTER_USE_BOTH,
+        );
+    }
+}

--- a/app/Http/Controllers/Admin/RestaurantSettingController.php
+++ b/app/Http/Controllers/Admin/RestaurantSettingController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\DTOs\UpdateRestaurantSettingDTO;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\UpdateRestaurantSettingRequest;
+use App\Http\Resources\RestaurantSettingResource;
+use App\Services\RestaurantSettingService;
+
+class RestaurantSettingController extends Controller
+{
+    public function __construct(private RestaurantSettingService $service) {}
+
+    public function show(): RestaurantSettingResource
+    {
+        return new RestaurantSettingResource($this->service->get());
+    }
+
+    public function update(UpdateRestaurantSettingRequest $request): RestaurantSettingResource
+    {
+        $settings = $this->service->update(
+            UpdateRestaurantSettingDTO::fromValidated($request->validated())
+        );
+
+        return new RestaurantSettingResource($settings);
+    }
+}

--- a/app/Http/Requests/UpdateRestaurantSettingRequest.php
+++ b/app/Http/Requests/UpdateRestaurantSettingRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateRestaurantSettingRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'deposit_per_person'                 => ['sometimes', 'numeric', 'min:0.01'],
+            'cancellation_deadline_hours'         => ['sometimes', 'integer', 'min:1', 'max:168'],
+            'refund_percentage'                   => ['sometimes', 'integer', 'min:0', 'max:100'],
+            'admin_fee_percentage'                => ['sometimes', 'integer', 'min:0', 'max:100'],
+            'default_reservation_duration_minutes' => ['sometimes', 'integer', 'min:15', 'max:480'],
+            'reminder_hours_before'               => ['sometimes', 'integer', 'min:1', 'max:168'],
+            'time_slot_interval_minutes'          => ['sometimes', 'integer', Rule::in([15, 30, 45, 60])],
+        ];
+    }
+}

--- a/app/Http/Resources/RestaurantSettingResource.php
+++ b/app/Http/Resources/RestaurantSettingResource.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class RestaurantSettingResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'deposit_per_person'                    => $this->deposit_per_person,
+            'cancellation_deadline_hours'           => $this->cancellation_deadline_hours,
+            'refund_percentage'                     => $this->refund_percentage,
+            'admin_fee_percentage'                  => $this->admin_fee_percentage,
+            'default_reservation_duration_minutes'  => $this->default_reservation_duration_minutes,
+            'reminder_hours_before'                 => $this->reminder_hours_before,
+            'time_slot_interval_minutes'            => $this->time_slot_interval_minutes,
+        ];
+    }
+}

--- a/app/Models/RestaurantSetting.php
+++ b/app/Models/RestaurantSetting.php
@@ -13,6 +13,7 @@ class RestaurantSetting extends Model
         'admin_fee_percentage',
         'default_reservation_duration_minutes',
         'reminder_hours_before',
+        'time_slot_interval_minutes',
     ];
 
     protected function casts(): array

--- a/app/Repositories/RestaurantSettingRepository.php
+++ b/app/Repositories/RestaurantSettingRepository.php
@@ -15,6 +15,6 @@ class RestaurantSettingRepository
     {
         $settings->update($data);
 
-        return $settings;
+        return $settings->fresh();
     }
 }

--- a/app/Services/ReservationService.php
+++ b/app/Services/ReservationService.php
@@ -64,6 +64,13 @@ class ReservationService
 
             $settings = $this->settingRepository->get();
 
+            $startTimeMinutes = Carbon::parse($dto->start_time)->minute;
+            if ($startTimeMinutes % $settings->time_slot_interval_minutes !== 0) {
+                throw ValidationException::withMessages([
+                    'start_time' => ["La hora de inicio debe estar alineada a intervalos de {$settings->time_slot_interval_minutes} minutos."],
+                ]);
+            }
+
             $endTime = Carbon::parse($dto->start_time)
                 ->addMinutes($settings->default_reservation_duration_minutes)
                 ->format('H:i:s');

--- a/app/Services/RestaurantSettingService.php
+++ b/app/Services/RestaurantSettingService.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Services;
+
+use App\DTOs\UpdateRestaurantSettingDTO;
+use App\Models\RestaurantSetting;
+use App\Repositories\RestaurantSettingRepository;
+
+class RestaurantSettingService
+{
+    public function __construct(private RestaurantSettingRepository $repository) {}
+
+    public function get(): RestaurantSetting
+    {
+        return $this->repository->get();
+    }
+
+    public function update(UpdateRestaurantSettingDTO $dto): RestaurantSetting
+    {
+        $settings = $this->repository->get();
+
+        return $this->repository->update($settings, $dto->toArray());
+    }
+}

--- a/database/migrations/2026_03_24_071506_add_time_slot_interval_minutes_to_restaurant_settings_table.php
+++ b/database/migrations/2026_03_24_071506_add_time_slot_interval_minutes_to_restaurant_settings_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('restaurant_settings', function (Blueprint $table) {
+            $table->unsignedSmallInteger('time_slot_interval_minutes')
+                ->default(30)
+                ->after('reminder_hours_before');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('restaurant_settings', function (Blueprint $table) {
+            $table->dropColumn('time_slot_interval_minutes');
+        });
+    }
+};

--- a/database/seeders/RestaurantSettingSeeder.php
+++ b/database/seeders/RestaurantSettingSeeder.php
@@ -16,6 +16,7 @@ class RestaurantSettingSeeder extends Seeder
             'admin_fee_percentage' => 10,
             'default_reservation_duration_minutes' => 120,
             'reminder_hours_before' => 24,
+            'time_slot_interval_minutes' => 30,
         ]);
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\Admin\AnalyticsController;
 use App\Http\Controllers\Admin\MenuItemController as AdminMenuItemController;
 use App\Http\Controllers\Admin\ReservationController as AdminReservationController;
+use App\Http\Controllers\Admin\RestaurantSettingController;
 use App\Http\Controllers\Admin\TableController;
 use App\Http\Controllers\Auth\AuthController;
 use App\Http\Controllers\Client\GuestReservationController;
@@ -35,6 +36,9 @@ Route::middleware(['auth:sanctum', 'role:admin'])->prefix('admin')->group(functi
         Route::get('/', [AdminReservationController::class, 'index']);
         Route::get('/{reservation}', [AdminReservationController::class, 'show']);
     });
+
+    Route::get('settings', [RestaurantSettingController::class, 'show']);
+    Route::patch('settings', [RestaurantSettingController::class, 'update']);
 
     Route::prefix('analytics')->group(function () {
         Route::get('/occupancy', [AnalyticsController::class, 'occupancy']);

--- a/tests/Feature/GuestReservationTest.php
+++ b/tests/Feature/GuestReservationTest.php
@@ -175,4 +175,16 @@ class GuestReservationTest extends TestCase
         $response->assertStatus(422)
             ->assertJsonValidationErrors(['reservation']);
     }
+
+    public function test_guest_hold_rejects_start_time_not_aligned_to_time_slot_interval(): void
+    {
+        $this->paymentServiceMock->shouldNotReceive('createPaymentIntent');
+
+        $response = $this->postJson('/api/guest/reservations', $this->guestHoldData([
+            'start_time' => '20:15',
+        ]));
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['start_time']);
+    }
 }

--- a/tests/Feature/ReservationTest.php
+++ b/tests/Feature/ReservationTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use App\Jobs\ExpireReservationJob;
 use App\Models\Payment;
 use App\Models\Reservation;
+use App\Models\RestaurantSetting;
 use App\Models\Table;
 use App\Services\PaymentService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -393,6 +394,57 @@ class ReservationTest extends TestCase
         $response->assertStatus(403);
     }
 
+    // ── Time slot interval ─────────────────────────────────
+
+    public function test_hold_rejects_start_time_not_aligned_to_time_slot_interval(): void
+    {
+        $this->paymentServiceMock->shouldNotReceive('createPaymentIntent');
+
+        $table = Table::factory()->create();
+
+        $response = $this->actingAs($this->clientUser())
+            ->postJson('/api/reservations', [
+                'table_id' => $table->id,
+                'seats_requested' => 2,
+                'date' => now()->addDays(3)->format('Y-m-d'),
+                'start_time' => '20:15',
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['start_time']);
+    }
+
+    public function test_hold_accepts_start_time_aligned_to_time_slot_interval(): void
+    {
+        Queue::fake();
+
+        $this->paymentServiceMock
+            ->shouldReceive('createPaymentIntent')
+            ->once()
+            ->andReturn([
+                'payment' => new Payment([
+                    'amount' => 10.00,
+                    'status' => Payment::STATUS_PENDING,
+                    'payment_gateway_id' => 'pi_test_slot',
+                ]),
+                'client_secret' => 'pi_test_slot_secret',
+            ]);
+
+        RestaurantSetting::first()->update(['time_slot_interval_minutes' => 15]);
+
+        $table = Table::factory()->create();
+
+        $response = $this->actingAs($this->clientUser())
+            ->postJson('/api/reservations', [
+                'table_id' => $table->id,
+                'seats_requested' => 2,
+                'date' => now()->addDays(3)->format('Y-m-d'),
+                'start_time' => '20:15',
+            ]);
+
+        $response->assertStatus(201);
+    }
+
     // ── Today booking ─────────────────────────────────────
 
     public function test_hold_allows_booking_for_today(): void
@@ -418,7 +470,7 @@ class ReservationTest extends TestCase
                 'table_id' => $table->id,
                 'seats_requested' => 2,
                 'date' => now()->format('Y-m-d'),
-                'start_time' => now()->addHours(2)->format('H:i'),
+                'start_time' => now()->addHours(2)->startOfHour()->format('H:i'),
             ]);
 
         $response->assertStatus(201);

--- a/tests/Feature/RestaurantSettingTest.php
+++ b/tests/Feature/RestaurantSettingTest.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\RestaurantSetting;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use Tests\Traits\CreatesUsers;
+
+class RestaurantSettingTest extends TestCase
+{
+    use RefreshDatabase;
+    use CreatesUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(\Database\Seeders\RoleSeeder::class);
+        $this->seed(\Database\Seeders\RestaurantSettingSeeder::class);
+    }
+
+    // ── Show ─────────────────────────────────────────────────
+
+    public function test_admin_can_view_settings(): void
+    {
+        $response = $this->actingAs($this->adminUser())
+            ->getJson('/api/admin/settings');
+
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'data' => [
+                    'deposit_per_person',
+                    'cancellation_deadline_hours',
+                    'refund_percentage',
+                    'admin_fee_percentage',
+                    'default_reservation_duration_minutes',
+                    'reminder_hours_before',
+                    'time_slot_interval_minutes',
+                ],
+            ]);
+    }
+
+    // ── Update ───────────────────────────────────────────────
+
+    public function test_admin_can_update_a_single_setting(): void
+    {
+        $response = $this->actingAs($this->adminUser())
+            ->patchJson('/api/admin/settings', [
+                'time_slot_interval_minutes' => 15,
+            ]);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.time_slot_interval_minutes', 15);
+
+        $this->assertDatabaseHas('restaurant_settings', [
+            'time_slot_interval_minutes' => 15,
+        ]);
+    }
+
+    public function test_admin_can_update_multiple_settings(): void
+    {
+        $response = $this->actingAs($this->adminUser())
+            ->patchJson('/api/admin/settings', [
+                'deposit_per_person' => 10.00,
+                'cancellation_deadline_hours' => 48,
+            ]);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.deposit_per_person', '10.00')
+            ->assertJsonPath('data.cancellation_deadline_hours', 48);
+    }
+
+    public function test_update_does_not_modify_fields_not_sent(): void
+    {
+        $original = RestaurantSetting::first();
+
+        $this->actingAs($this->adminUser())
+            ->patchJson('/api/admin/settings', [
+                'time_slot_interval_minutes' => 60,
+            ]);
+
+        $updated = RestaurantSetting::first();
+
+        $this->assertEquals($original->deposit_per_person, $updated->deposit_per_person);
+        $this->assertEquals($original->cancellation_deadline_hours, $updated->cancellation_deadline_hours);
+        $this->assertEquals(60, $updated->time_slot_interval_minutes);
+    }
+
+    // ── Validation ───────────────────────────────────────────
+
+    public function test_update_rejects_invalid_time_slot_interval(): void
+    {
+        $response = $this->actingAs($this->adminUser())
+            ->patchJson('/api/admin/settings', [
+                'time_slot_interval_minutes' => 20,
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['time_slot_interval_minutes']);
+    }
+
+    public function test_update_rejects_negative_deposit(): void
+    {
+        $response = $this->actingAs($this->adminUser())
+            ->patchJson('/api/admin/settings', [
+                'deposit_per_person' => -5,
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['deposit_per_person']);
+    }
+
+    public function test_update_rejects_refund_percentage_above_100(): void
+    {
+        $response = $this->actingAs($this->adminUser())
+            ->patchJson('/api/admin/settings', [
+                'refund_percentage' => 150,
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['refund_percentage']);
+    }
+
+    // ── Authorization ────────────────────────────────────────
+
+    public function test_client_cannot_access_settings(): void
+    {
+        $this->actingAs($this->clientUser())
+            ->getJson('/api/admin/settings')
+            ->assertStatus(403);
+
+        $this->actingAs($this->clientUser())
+            ->patchJson('/api/admin/settings', ['time_slot_interval_minutes' => 15])
+            ->assertStatus(403);
+    }
+
+    public function test_unauthenticated_user_cannot_access_settings(): void
+    {
+        $this->getJson('/api/admin/settings')
+            ->assertStatus(401);
+
+        $this->patchJson('/api/admin/settings', ['time_slot_interval_minutes' => 15])
+            ->assertStatus(401);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `time_slot_interval_minutes` column to `restaurant_settings` (default 30, predefined values: 15, 30, 45, 60)
- Create admin settings endpoint (`GET /admin/settings`, `PATCH /admin/settings`) with partial update support
- Enforce reservation `start_time` alignment to the configured interval for both authenticated and guest users
- Fix `RestaurantSettingRepository.update()` to return `fresh()` after update

## Test plan

- [x] Admin can view settings (GET /admin/settings returns all fields)
- [x] Admin can update a single setting (partial PATCH)
- [x] Admin can update multiple settings at once
- [x] Update does not modify fields not sent
- [x] Invalid time slot interval (e.g. 20) is rejected with 422
- [x] Negative deposit and percentage above 100 are rejected
- [x] Client and unauthenticated users cannot access settings (403/401)
- [x] Reservation hold rejects start_time not aligned to interval (e.g. 20:15 with interval 30)
- [x] Reservation hold accepts start_time aligned to interval (e.g. 20:15 with interval 15)
- [x] Guest reservation hold rejects unaligned start_time
- [x] All 148 tests pass

Closes #57