### PR TITLE
Revoke guest tokens when account is completed

### DIFF
--- a/app/Services/AuthService.php
+++ b/app/Services/AuthService.php
@@ -65,6 +65,8 @@ class AuthService
 
         $this->userRepository->update($user, ['password' => $dto->password]);
 
+        $user->tokens()->delete();
+
         return $user;
     }
 

--- a/tests/Feature/CompleteAccountTest.php
+++ b/tests/Feature/CompleteAccountTest.php
@@ -75,6 +75,22 @@ class CompleteAccountTest extends TestCase
             ->assertJsonValidationErrors(['password']);
     }
 
+    public function test_complete_account_revokes_all_tokens(): void
+    {
+        $user = $this->lazyUser();
+        $user->createToken('guest-token');
+
+        $this->assertDatabaseCount('personal_access_tokens', 1);
+
+        $this->actingAs($user)
+            ->postJson('/api/auth/complete-account', [
+                'password' => 'NewPassword1',
+                'password_confirmation' => 'NewPassword1',
+            ]);
+
+        $this->assertDatabaseCount('personal_access_tokens', 0);
+    }
+
     public function test_unauthenticated_user_cannot_complete_account(): void
     {
         $response = $this->postJson('/api/auth/complete-account', [


### PR DESCRIPTION
## Summary

- Revoke all user tokens in `AuthService::completeAccount()` after password is set
- Guest must login with new credentials after completing their account

## Test plan

- [x] Guest tokens are deleted after completing account
- [x] Registered user cannot complete account (422)
- [x] Missing fields rejected (422)
- [x] Unauthenticated user cannot access endpoint (401)
- [x] All 149 tests pass

Closes #59