### PR TITLE
Add available tables endpoint for reservation by party size

### DIFF
--- a/app/DTOs/AvailableTablesDTO.php
+++ b/app/DTOs/AvailableTablesDTO.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\DTOs;
+
+readonly class AvailableTablesDTO
+{
+    public function __construct(
+        public int $seats_requested,
+        public string $date,
+        public string $start_time,
+    ) {}
+}

--- a/app/Http/Controllers/Client/ReservationController.php
+++ b/app/Http/Controllers/Client/ReservationController.php
@@ -2,10 +2,13 @@
 
 namespace App\Http\Controllers\Client;
 
+use App\DTOs\AvailableTablesDTO;
 use App\DTOs\HoldReservationDTO;
 use App\Http\Controllers\Controller;
+use App\Http\Requests\AvailableTablesRequest;
 use App\Http\Requests\HoldReservationRequest;
 use App\Http\Resources\ReservationResource;
+use App\Http\Resources\TableResource;
 use App\Models\Reservation;
 use App\Services\ReservationService;
 use Illuminate\Http\JsonResponse;
@@ -14,6 +17,15 @@ use Illuminate\Http\Request;
 class ReservationController extends Controller
 {
     public function __construct(private ReservationService $service) {}
+
+    public function availableTables(AvailableTablesRequest $request): JsonResponse
+    {
+        $dto = new AvailableTablesDTO(...$request->validated());
+
+        $tables = $this->service->suggestAvailableTables($dto);
+
+        return TableResource::collection($tables)->response();
+    }
 
     public function store(HoldReservationRequest $request): JsonResponse
     {

--- a/app/Http/Requests/AvailableTablesRequest.php
+++ b/app/Http/Requests/AvailableTablesRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class AvailableTablesRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'seats_requested' => ['required', 'integer', 'min:1'],
+            'date' => ['required', 'date_format:Y-m-d'],
+            'start_time' => ['required', 'date_format:H:i'],
+        ];
+    }
+}

--- a/app/Repositories/TableRepository.php
+++ b/app/Repositories/TableRepository.php
@@ -2,8 +2,10 @@
 
 namespace App\Repositories;
 
+use App\Models\Reservation;
 use App\Models\Table;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Database\Eloquent\Collection;
 
 class TableRepository
 {
@@ -37,5 +39,22 @@ class TableRepository
     public function delete(Table $table): void
     {
         $table->delete();
+    }
+
+    public function findAvailable(int $seatsRequested, string $date, string $startTime, string $endTime): Collection
+    {
+        return Table::where('is_active', true)
+            ->where('min_capacity', '<=', $seatsRequested)
+            ->where('max_capacity', '>=', $seatsRequested)
+            ->whereNotIn('id', function ($query) use ($date, $startTime, $endTime) {
+                $query->select('table_id')
+                    ->from('reservations')
+                    ->whereIn('status', [Reservation::STATUS_PENDING, Reservation::STATUS_CONFIRMED])
+                    ->where('date', $date)
+                    ->where('start_time', '<', $endTime)
+                    ->where('end_time', '>', $startTime);
+            })
+            ->orderBy('max_capacity')
+            ->get();
     }
 }

--- a/app/Services/ReservationService.php
+++ b/app/Services/ReservationService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\DTOs\AvailableTablesDTO;
 use App\DTOs\HoldReservationDTO;
 use App\Jobs\ExpireReservationJob;
 use App\Notifications\ReservationCancelledNotification;
@@ -15,6 +16,7 @@ use App\Repositories\RestaurantSettingRepository;
 use App\Repositories\TableRepository;
 use Carbon\Carbon;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\ValidationException;
 
@@ -212,5 +214,31 @@ class ReservationService
     public function listAll(int $perPage = 6): LengthAwarePaginator
     {
         return $this->reservationRepository->paginate($perPage);
+    }
+
+    public function suggestAvailableTables(AvailableTablesDTO $dto): Collection
+    {
+        $reservationDateTime = Carbon::parse($dto->date . ' ' . $dto->start_time);
+
+        if ($reservationDateTime->isPast() || Carbon::parse($dto->date)->greaterThan(now()->addWeek())) {
+            throw ValidationException::withMessages([
+                'date' => ['Las reservas deben ser dentro de los proximos 7 dias.'],
+            ]);
+        }
+
+        $settings = $this->settingRepository->get();
+
+        $startTimeMinutes = Carbon::parse($dto->start_time)->minute;
+        if ($startTimeMinutes % $settings->time_slot_interval_minutes !== 0) {
+            throw ValidationException::withMessages([
+                'start_time' => ["La hora de inicio debe estar alineada a intervalos de {$settings->time_slot_interval_minutes} minutos."],
+            ]);
+        }
+
+        $endTime = Carbon::parse($dto->start_time)
+            ->addMinutes($settings->default_reservation_duration_minutes)
+            ->format('H:i:s');
+
+        return $this->tableRepository->findAvailable($dto->seats_requested, $dto->date, $dto->start_time, $endTime);
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -26,6 +26,7 @@ Route::prefix('auth')->group(function () {
 });
 
 Route::get('menu-items', [ClientMenuItemController::class, 'index']);
+Route::get('reservations/available-tables', [ClientReservationController::class, 'availableTables']);
 Route::post('guest/reservations', [GuestReservationController::class, 'store']);
 
 Route::middleware(['auth:sanctum', 'role:admin'])->prefix('admin')->group(function () {

--- a/tests/Feature/AvailableTablesTest.php
+++ b/tests/Feature/AvailableTablesTest.php
@@ -1,0 +1,192 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Reservation;
+use App\Models\Table;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AvailableTablesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $date;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed(\Database\Seeders\RoleSeeder::class);
+        $this->seed(\Database\Seeders\RestaurantSettingSeeder::class);
+
+        $this->date = now()->addDays(3)->format('Y-m-d');
+    }
+
+    private function queryParams(array $overrides = []): array
+    {
+        return array_merge([
+            'seats_requested' => 4,
+            'date' => $this->date,
+            'start_time' => '20:00',
+        ], $overrides);
+    }
+
+    // ── Filtering ────────────────────────────────────────────
+
+    public function test_returns_available_tables_matching_capacity(): void
+    {
+        Table::factory()->create(['min_capacity' => 2, 'max_capacity' => 6]);
+        Table::factory()->create(['min_capacity' => 8, 'max_capacity' => 10]);
+
+        $response = $this->getJson('/api/reservations/available-tables?' . http_build_query($this->queryParams()));
+
+        $response->assertStatus(200)
+            ->assertJsonCount(1, 'data');
+    }
+
+    public function test_does_not_return_inactive_tables(): void
+    {
+        Table::factory()->create(['min_capacity' => 2, 'max_capacity' => 6, 'is_active' => true]);
+        Table::factory()->create(['min_capacity' => 2, 'max_capacity' => 6, 'is_active' => false]);
+
+        $response = $this->getJson('/api/reservations/available-tables?' . http_build_query($this->queryParams()));
+
+        $response->assertStatus(200)
+            ->assertJsonCount(1, 'data');
+    }
+
+    public function test_does_not_return_tables_with_overlapping_reservation(): void
+    {
+        $table = Table::factory()->create(['min_capacity' => 2, 'max_capacity' => 6]);
+
+        Reservation::factory()->confirmed()->create([
+            'table_id' => $table->id,
+            'date' => $this->date,
+            'start_time' => '19:00:00',
+            'end_time' => '21:00:00',
+        ]);
+
+        $response = $this->getJson('/api/reservations/available-tables?' . http_build_query($this->queryParams()));
+
+        $response->assertStatus(200)
+            ->assertJsonCount(0, 'data');
+    }
+
+    public function test_returns_table_when_reservation_does_not_overlap(): void
+    {
+        $table = Table::factory()->create(['min_capacity' => 2, 'max_capacity' => 6]);
+
+        Reservation::factory()->confirmed()->create([
+            'table_id' => $table->id,
+            'date' => $this->date,
+            'start_time' => '16:00:00',
+            'end_time' => '18:00:00',
+        ]);
+
+        $response = $this->getJson('/api/reservations/available-tables?' . http_build_query($this->queryParams()));
+
+        $response->assertStatus(200)
+            ->assertJsonCount(1, 'data');
+    }
+
+    public function test_ignores_cancelled_and_expired_reservations(): void
+    {
+        $table = Table::factory()->create(['min_capacity' => 2, 'max_capacity' => 6]);
+
+        Reservation::factory()->cancelled()->create([
+            'table_id' => $table->id,
+            'date' => $this->date,
+            'start_time' => '19:00:00',
+            'end_time' => '21:00:00',
+        ]);
+
+        Reservation::factory()->expired()->create([
+            'table_id' => $table->id,
+            'date' => $this->date,
+            'start_time' => '19:00:00',
+            'end_time' => '21:00:00',
+        ]);
+
+        $response = $this->getJson('/api/reservations/available-tables?' . http_build_query($this->queryParams()));
+
+        $response->assertStatus(200)
+            ->assertJsonCount(1, 'data');
+    }
+
+    public function test_returns_empty_when_no_tables_available(): void
+    {
+        $response = $this->getJson('/api/reservations/available-tables?' . http_build_query($this->queryParams()));
+
+        $response->assertStatus(200)
+            ->assertJsonCount(0, 'data');
+    }
+
+    // ── Ordering ─────────────────────────────────────────────
+
+    public function test_orders_by_best_fit(): void
+    {
+        Table::factory()->create(['name' => 'Grande', 'min_capacity' => 4, 'max_capacity' => 10]);
+        Table::factory()->create(['name' => 'Justa', 'min_capacity' => 2, 'max_capacity' => 4]);
+        Table::factory()->create(['name' => 'Mediana', 'min_capacity' => 2, 'max_capacity' => 6]);
+
+        $response = $this->getJson('/api/reservations/available-tables?' . http_build_query($this->queryParams()));
+
+        $response->assertStatus(200)
+            ->assertJsonCount(3, 'data')
+            ->assertJsonPath('data.0.name', 'Justa')
+            ->assertJsonPath('data.1.name', 'Mediana')
+            ->assertJsonPath('data.2.name', 'Grande');
+    }
+
+    // ── Validation ───────────────────────────────────────────
+
+    public function test_rejects_missing_fields(): void
+    {
+        $response = $this->getJson('/api/reservations/available-tables');
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['seats_requested', 'date', 'start_time']);
+    }
+
+    public function test_rejects_past_date(): void
+    {
+        $response = $this->getJson('/api/reservations/available-tables?' . http_build_query(
+            $this->queryParams(['date' => now()->subDay()->format('Y-m-d')])
+        ));
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['date']);
+    }
+
+    public function test_rejects_date_beyond_one_week(): void
+    {
+        $response = $this->getJson('/api/reservations/available-tables?' . http_build_query(
+            $this->queryParams(['date' => now()->addDays(8)->format('Y-m-d')])
+        ));
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['date']);
+    }
+
+    public function test_rejects_start_time_not_aligned_to_interval(): void
+    {
+        $response = $this->getJson('/api/reservations/available-tables?' . http_build_query(
+            $this->queryParams(['start_time' => '20:15'])
+        ));
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['start_time']);
+    }
+
+    // ── Access ────────────────────────────────────────────────
+
+    public function test_endpoint_is_public(): void
+    {
+        Table::factory()->create(['min_capacity' => 2, 'max_capacity' => 6]);
+
+        $response = $this->getJson('/api/reservations/available-tables?' . http_build_query($this->queryParams()));
+
+        $response->assertStatus(200);
+    }
+}


### PR DESCRIPTION
## Summary

- Add public `GET /reservations/available-tables` endpoint
- Accepts `seats_requested`, `date`, and `start_time` as query params
- Returns active tables matching capacity with no overlapping reservations
- Ordered by best fit (smallest max_capacity first)
- Validates date (future, within 7 days) and start_time (aligned to interval)

## Test plan

- [x] Returns tables matching requested capacity
- [x] Filters out inactive tables
- [x] Filters out tables with overlapping reservations (pending/confirmed)
- [x] Includes tables when reservation does not overlap
- [x] Ignores cancelled and expired reservations
- [x] Returns empty list when no tables available
- [x] Orders by best fit (smallest max_capacity first)
- [x] Rejects missing fields (422)
- [x] Rejects past date (422)
- [x] Rejects date beyond one week (422)
- [x] Rejects start_time not aligned to interval (422)
- [x] Endpoint is publicly accessible without auth
- [x] All 161 tests pass

Closes #61