### PR TITLE
Add forgot/reset password flow with smart guest handling

### DIFF
--- a/app/DTOs/ForgotPasswordDTO.php
+++ b/app/DTOs/ForgotPasswordDTO.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\DTOs;
+
+readonly class ForgotPasswordDTO
+{
+    public function __construct(
+        public string $email,
+    ) {}
+}

--- a/app/DTOs/ResetPasswordDTO.php
+++ b/app/DTOs/ResetPasswordDTO.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\DTOs;
+
+readonly class ResetPasswordDTO
+{
+    public function __construct(
+        public string $email,
+        public string $token,
+        public string $password,
+        public string $password_confirmation,
+    ) {}
+}

--- a/app/Http/Controllers/Auth/AuthController.php
+++ b/app/Http/Controllers/Auth/AuthController.php
@@ -3,12 +3,16 @@
 namespace App\Http\Controllers\Auth;
 
 use App\DTOs\CompleteAccountDTO;
+use App\DTOs\ForgotPasswordDTO;
 use App\DTOs\LoginDTO;
 use App\DTOs\RegisterDTO;
+use App\DTOs\ResetPasswordDTO;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\CompleteAccountRequest;
+use App\Http\Requests\ForgotPasswordRequest;
 use App\Http\Requests\LoginRequest;
 use App\Http\Requests\RegisterRequest;
+use App\Http\Requests\ResetPasswordRequest;
 use App\Http\Resources\UserResource;
 use App\Services\AuthService;
 use Illuminate\Http\JsonResponse;
@@ -55,6 +59,24 @@ class AuthController extends Controller
 
         return response()->json([
             'data' => new UserResource($user),
+        ]);
+    }
+
+    public function forgotPassword(ForgotPasswordRequest $request): JsonResponse
+    {
+        $this->authService->forgotPassword(new ForgotPasswordDTO(...$request->validated()));
+
+        return response()->json([
+            'message' => 'Si tu correo esta registrado, recibiras instrucciones para restablecer tu contrasena.',
+        ]);
+    }
+
+    public function resetPassword(ResetPasswordRequest $request): JsonResponse
+    {
+        $this->authService->resetPassword(new ResetPasswordDTO(...$request->validated()));
+
+        return response()->json([
+            'message' => 'Tu contrasena ha sido restablecida exitosamente.',
         ]);
     }
 

--- a/app/Http/Requests/ForgotPasswordRequest.php
+++ b/app/Http/Requests/ForgotPasswordRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ForgotPasswordRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'email' => ['required', 'string', 'email'],
+        ];
+    }
+}

--- a/app/Http/Requests/ResetPasswordRequest.php
+++ b/app/Http/Requests/ResetPasswordRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rules\Password;
+
+class ResetPasswordRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'email'                 => ['required', 'string', 'email'],
+            'token'                 => ['required', 'string'],
+            'password'              => ['required', 'string', Password::min(8)->mixedCase()->numbers(), 'confirmed'],
+            'password_confirmation' => ['required', 'string'],
+        ];
+    }
+}

--- a/app/Notifications/AccountCompletionNotification.php
+++ b/app/Notifications/AccountCompletionNotification.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class AccountCompletionNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(private string $token)
+    {
+    }
+
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage())
+            ->subject('Completa tu cuenta')
+            ->greeting("Hola, {$notifiable->name}!")
+            ->line('Tienes una cuenta pendiente de completar. Establece una contrasena para acceder a todas las funcionalidades.')
+            ->line('Tu codigo para establecer tu contrasena es:')
+            ->line($this->token)
+            ->line('Este codigo expira en 60 minutos.')
+            ->line('Si no solicitaste esto, puedes ignorar este correo.');
+    }
+}

--- a/app/Notifications/ResetPasswordNotification.php
+++ b/app/Notifications/ResetPasswordNotification.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class ResetPasswordNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(private string $token)
+    {
+    }
+
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage())
+            ->subject('Restablecer contrasena')
+            ->greeting("Hola, {$notifiable->name}!")
+            ->line('Recibimos una solicitud para restablecer la contrasena de tu cuenta.')
+            ->line('Tu codigo de restablecimiento es:')
+            ->line($this->token)
+            ->line('Este codigo expira en 60 minutos.')
+            ->line('Si no solicitaste este cambio, puedes ignorar este correo. Tu contrasena no sera modificada.');
+    }
+}

--- a/app/Services/AuthService.php
+++ b/app/Services/AuthService.php
@@ -3,12 +3,17 @@
 namespace App\Services;
 
 use App\DTOs\CompleteAccountDTO;
+use App\DTOs\ForgotPasswordDTO;
 use App\DTOs\LoginDTO;
 use App\DTOs\RegisterDTO;
+use App\DTOs\ResetPasswordDTO;
 use App\Models\User;
+use App\Notifications\AccountCompletionNotification;
+use App\Notifications\ResetPasswordNotification;
 use App\Repositories\UserRepository;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Password;
 use Illuminate\Validation\ValidationException;
 use Laravel\Sanctum\PersonalAccessToken;
 
@@ -68,6 +73,51 @@ class AuthService
         $user->tokens()->delete();
 
         return $user;
+    }
+
+    public function forgotPassword(ForgotPasswordDTO $dto): void
+    {
+        $user = $this->userRepository->findByEmail($dto->email);
+
+        if (! $user) {
+            return;
+        }
+
+        $broker = Password::broker();
+
+        if ($broker->getRepository()->recentlyCreatedToken($user)) {
+            return;
+        }
+
+        $token = $broker->createToken($user);
+
+        $notification = $user->isGuest()
+            ? new AccountCompletionNotification($token)
+            : new ResetPasswordNotification($token);
+
+        $user->notify($notification);
+    }
+
+    public function resetPassword(ResetPasswordDTO $dto): void
+    {
+        $status = Password::reset(
+            [
+                'email'                 => $dto->email,
+                'token'                 => $dto->token,
+                'password'              => $dto->password,
+                'password_confirmation' => $dto->password_confirmation,
+            ],
+            function (User $user, string $password) {
+                $this->userRepository->update($user, ['password' => $password]);
+                $user->tokens()->delete();
+            }
+        );
+
+        if ($status !== Password::PASSWORD_RESET) {
+            throw ValidationException::withMessages([
+                'email' => ['El token de restablecimiento es invalido o ha expirado.'],
+            ]);
+        }
     }
 
     public function logout(User $user): void

--- a/routes/api.php
+++ b/routes/api.php
@@ -17,6 +17,8 @@ Route::prefix('auth')->group(function () {
     Route::middleware('throttle:5,1')->group(function () {
         Route::post('/register', [AuthController::class, 'register']);
         Route::post('/login', [AuthController::class, 'login']);
+        Route::post('/forgot-password', [AuthController::class, 'forgotPassword']);
+        Route::post('/reset-password', [AuthController::class, 'resetPassword']);
     });
 
     Route::middleware('auth:sanctum')->group(function () {

--- a/tests/Feature/Auth/ForgotPasswordTest.php
+++ b/tests/Feature/Auth/ForgotPasswordTest.php
@@ -1,0 +1,212 @@
+<?php
+
+namespace Tests\Feature\Auth;
+
+use App\Models\User;
+use App\Notifications\AccountCompletionNotification;
+use App\Notifications\ResetPasswordNotification;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Password;
+use Tests\TestCase;
+
+class ForgotPasswordTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const GENERIC_MESSAGE = 'Si tu correo esta registrado, recibiras instrucciones para restablecer tu contrasena.';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(\Database\Seeders\RoleSeeder::class);
+    }
+
+    public function test_forgot_password_sends_reset_notification_to_user_with_password(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->create();
+
+        $this->postJson('/api/auth/forgot-password', ['email' => $user->email])
+            ->assertOk()
+            ->assertJson(['message' => self::GENERIC_MESSAGE]);
+
+        Notification::assertSentTo($user, ResetPasswordNotification::class);
+    }
+
+    public function test_forgot_password_sends_account_completion_notification_to_guest(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->create(['password' => null]);
+
+        $this->postJson('/api/auth/forgot-password', ['email' => $user->email])
+            ->assertOk()
+            ->assertJson(['message' => self::GENERIC_MESSAGE]);
+
+        Notification::assertSentTo($user, AccountCompletionNotification::class);
+        Notification::assertNotSentTo($user, ResetPasswordNotification::class);
+    }
+
+    public function test_forgot_password_returns_same_response_for_nonexistent_email(): void
+    {
+        Notification::fake();
+
+        $this->postJson('/api/auth/forgot-password', ['email' => 'nobody@example.com'])
+            ->assertOk()
+            ->assertJson(['message' => self::GENERIC_MESSAGE]);
+
+        Notification::assertNothingSent();
+    }
+
+    public function test_forgot_password_is_throttled_by_broker(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->create();
+
+        $this->postJson('/api/auth/forgot-password', ['email' => $user->email]);
+        $this->postJson('/api/auth/forgot-password', ['email' => $user->email]);
+
+        Notification::assertSentToTimes($user, ResetPasswordNotification::class, 1);
+    }
+
+    public function test_forgot_password_validates_email_format(): void
+    {
+        $this->postJson('/api/auth/forgot-password', ['email' => 'not-an-email'])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['email']);
+    }
+
+    public function test_reset_password_updates_password_successfully(): void
+    {
+        $user = User::factory()->create();
+        $token = Password::broker()->createToken($user);
+
+        $this->postJson('/api/auth/reset-password', [
+            'email'                 => $user->email,
+            'token'                 => $token,
+            'password'              => 'NewPassword1',
+            'password_confirmation' => 'NewPassword1',
+        ])
+            ->assertOk()
+            ->assertJson(['message' => 'Tu contrasena ha sido restablecida exitosamente.']);
+
+        $this->assertTrue(Hash::check('NewPassword1', $user->fresh()->password));
+    }
+
+    public function test_reset_password_works_for_guest_user(): void
+    {
+        $user = User::factory()->create(['password' => null]);
+        $token = Password::broker()->createToken($user);
+
+        $this->postJson('/api/auth/reset-password', [
+            'email'                 => $user->email,
+            'token'                 => $token,
+            'password'              => 'NewPassword1',
+            'password_confirmation' => 'NewPassword1',
+        ])->assertOk();
+
+        $fresh = $user->fresh();
+        $this->assertTrue(Hash::check('NewPassword1', $fresh->password));
+        $this->assertFalse($fresh->isGuest());
+    }
+
+    public function test_reset_password_revokes_all_sanctum_tokens(): void
+    {
+        $user = User::factory()->create();
+        $user->createToken('api-token');
+        $user->createToken('api-token');
+        $token = Password::broker()->createToken($user);
+
+        $this->postJson('/api/auth/reset-password', [
+            'email'                 => $user->email,
+            'token'                 => $token,
+            'password'              => 'NewPassword1',
+            'password_confirmation' => 'NewPassword1',
+        ])->assertOk();
+
+        $this->assertCount(0, $user->fresh()->tokens);
+    }
+
+    public function test_reset_password_fails_with_invalid_token(): void
+    {
+        $user = User::factory()->create();
+
+        $this->postJson('/api/auth/reset-password', [
+            'email'                 => $user->email,
+            'token'                 => 'invalid-token',
+            'password'              => 'NewPassword1',
+            'password_confirmation' => 'NewPassword1',
+        ])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['email']);
+    }
+
+    public function test_reset_password_fails_with_expired_token(): void
+    {
+        $user = User::factory()->create();
+        $token = Password::broker()->createToken($user);
+
+        $this->travel(61)->minutes();
+
+        $this->postJson('/api/auth/reset-password', [
+            'email'                 => $user->email,
+            'token'                 => $token,
+            'password'              => 'NewPassword1',
+            'password_confirmation' => 'NewPassword1',
+        ])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['email']);
+    }
+
+    public function test_reset_password_rejects_weak_password(): void
+    {
+        $user = User::factory()->create();
+        $token = Password::broker()->createToken($user);
+
+        $this->postJson('/api/auth/reset-password', [
+            'email'                 => $user->email,
+            'token'                 => $token,
+            'password'              => '12345678',
+            'password_confirmation' => '12345678',
+        ])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['password']);
+    }
+
+    public function test_reset_password_requires_password_confirmation(): void
+    {
+        $user = User::factory()->create();
+        $token = Password::broker()->createToken($user);
+
+        $this->postJson('/api/auth/reset-password', [
+            'email' => $user->email,
+            'token' => $token,
+            'password' => 'NewPassword1',
+        ])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['password']);
+    }
+
+    public function test_user_can_login_with_new_password_after_reset(): void
+    {
+        $user = User::factory()->create();
+        $user->assignRole('client');
+        $token = Password::broker()->createToken($user);
+
+        $this->postJson('/api/auth/reset-password', [
+            'email'                 => $user->email,
+            'token'                 => $token,
+            'password'              => 'NewPassword1',
+            'password_confirmation' => 'NewPassword1',
+        ])->assertOk();
+
+        $this->postJson('/api/auth/login', [
+            'email'    => $user->email,
+            'password' => 'NewPassword1',
+        ])->assertOk();
+    }
+}


### PR DESCRIPTION
## Summary

- Add `POST /api/auth/forgot-password` endpoint using Laravel's Password Broker
- Add `POST /api/auth/reset-password` endpoint that validates token and updates password
- Smart guest detection: guests receive an account completion notification instead of a reset notification
- Always return generic success message on forgot-password to prevent email enumeration
- Revoke all Sanctum tokens on successful password reset
- Both endpoints rate-limited (5 req/min) and broker-throttled (60 sec between tokens)

## Test plan

- [x] Forgot password sends ResetPasswordNotification to user with password
- [x] Forgot password sends AccountCompletionNotification to guest user
- [x] Forgot password returns same response for non-existent email (security)
- [x] Forgot password is throttled by broker (60 sec)
- [x] Forgot password validates email format
- [x] Reset password updates password successfully
- [x] Reset password works for guest user (first-time set)
- [x] Reset password revokes all Sanctum tokens
- [x] Reset password fails with invalid token
- [x] Reset password fails with expired token (60 min)
- [x] Reset password rejects weak password
- [x] Reset password requires password confirmation
- [x] User can login with new password after reset
- [x] Full test suite passes (174 tests, 0 failures)

Closes #63