### PR TITLE
Add Filament MenuItemResource for admin CRUD management

### DIFF
--- a/app/Filament/Resources/MenuItemResource.php
+++ b/app/Filament/Resources/MenuItemResource.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Enums\MenuCategory;
+use App\Filament\Resources\MenuItemResource\Pages;
+use App\Models\MenuItem;
+use BackedEnum;
+use Filament\Actions;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
+use Filament\Resources\Resource;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables;
+use Filament\Tables\Columns\IconColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Filters\TernaryFilter;
+
+class MenuItemResource extends Resource
+{
+    protected static ?string $model = MenuItem::class;
+
+    protected static string | BackedEnum | null $navigationIcon = Heroicon::OutlinedBookOpen;
+
+    protected static ?string $navigationLabel = 'Platos';
+
+    protected static ?string $modelLabel = 'Plato';
+
+    protected static ?string $pluralModelLabel = 'Platos';
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema
+            ->schema([
+                Section::make()
+                    ->schema([
+                        TextInput::make('name')
+                            ->label('Nombre')
+                            ->required()
+                            ->maxLength(255)
+                            ->unique(ignoreRecord: true),
+
+                        TextInput::make('price')
+                            ->label('Precio')
+                            ->required()
+                            ->numeric()
+                            ->minValue(0.01)
+                            ->prefix('€'),
+
+                        Select::make('category')
+                            ->label('Categoria')
+                            ->options(MenuCategory::class)
+                            ->required(),
+
+                        TextInput::make('daily_stock')
+                            ->label('Stock diario')
+                            ->numeric()
+                            ->minValue(0)
+                            ->helperText('Dejar vacio para stock ilimitado'),
+
+                        Textarea::make('description')
+                            ->label('Descripcion')
+                            ->maxLength(1000)
+                            ->columnSpanFull(),
+
+                        Toggle::make('is_available')
+                            ->label('Disponible')
+                            ->default(true),
+                    ])
+                    ->columns(2),
+            ]);
+    }
+
+    public static function table(Tables\Table $table): Tables\Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('name')
+                    ->label('Nombre')
+                    ->searchable()
+                    ->sortable(),
+
+                TextColumn::make('price')
+                    ->label('Precio')
+                    ->money('EUR', locale: 'es')
+                    ->sortable(),
+
+                TextColumn::make('category')
+                    ->label('Categoria')
+                    ->sortable()
+                    ->badge()
+                    ->color(fn(MenuCategory $state): string => match ($state) {
+                        MenuCategory::Entrantes => 'info',
+                        MenuCategory::Principales => 'success',
+                        MenuCategory::Postres => 'warning',
+                        MenuCategory::Bebidas => 'primary',
+                    }),
+
+                TextColumn::make('daily_stock')
+                    ->label('Stock diario')
+                    ->sortable()
+                    ->placeholder('Ilimitado'),
+
+                IconColumn::make('is_available')
+                    ->label('Disponible')
+                    ->boolean(),
+            ])
+            ->filters([
+                TernaryFilter::make('is_available')
+                    ->label('Disponibilidad')
+                    ->trueLabel('Disponibles')
+                    ->falseLabel('No disponibles'),
+
+                SelectFilter::make('category')
+                    ->label('Categoria')
+                    ->options(MenuCategory::class),
+            ])
+            ->recordActions([
+                Actions\EditAction::make(),
+            ])
+            ->toolbarActions([
+                Actions\DeleteBulkAction::make(),
+            ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListMenuItems::route('/'),
+            'create' => Pages\CreateMenuItem::route('/create'),
+            'edit' => Pages\EditMenuItem::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/MenuItemResource/Pages/CreateMenuItem.php
+++ b/app/Filament/Resources/MenuItemResource/Pages/CreateMenuItem.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\MenuItemResource\Pages;
+
+use App\Filament\Resources\MenuItemResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateMenuItem extends CreateRecord
+{
+    protected static string $resource = MenuItemResource::class;
+}

--- a/app/Filament/Resources/MenuItemResource/Pages/EditMenuItem.php
+++ b/app/Filament/Resources/MenuItemResource/Pages/EditMenuItem.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\MenuItemResource\Pages;
+
+use App\Filament\Resources\MenuItemResource;
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Pages\EditRecord;
+
+class EditMenuItem extends EditRecord
+{
+    protected static string $resource = MenuItemResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/MenuItemResource/Pages/ListMenuItems.php
+++ b/app/Filament/Resources/MenuItemResource/Pages/ListMenuItems.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\MenuItemResource\Pages;
+
+use App\Filament\Resources\MenuItemResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListMenuItems extends ListRecords
+{
+    protected static string $resource = MenuItemResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- Add MenuItemResource with full CRUD for managing menu items in the Filament admin panel
- Form fields: name, price (EUR), category (Select from MenuCategory enum), daily_stock, description, is_available toggle
- Table with searchable/sortable columns, colored category badges, EUR formatting with Spanish locale
- Filters: TernaryFilter on availability, SelectFilter on category
- Pages: ListMenuItems, CreateMenuItem, EditMenuItem following TableResource patterns

## Test plan
- [x] Routes registered via `php artisan route:list --path=admin/menu-items`
- [x] List menu items at `/admin/menu-items`
- [x] Create a new menu item with all fields
- [x] Edit an existing menu item
- [x] Delete a menu item
- [x] Filter by availability and category
- [x] Search by name
- [x] Price displays in EUR format with Spanish locale

Closes #69