### PR TITLE
Add job to auto-complete reservations after end time

### DIFF
--- a/app/Jobs/AutoCompleteReservationsJob.php
+++ b/app/Jobs/AutoCompleteReservationsJob.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Reservation;
+use App\Repositories\ReservationRepository;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class AutoCompleteReservationsJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function handle(ReservationRepository $reservationRepository): void
+    {
+        $reservations = $reservationRepository->findCompletable();
+
+        foreach ($reservations as $reservation) {
+            $reservationRepository->updateStatus($reservation, Reservation::STATUS_COMPLETED);
+        }
+    }
+}

--- a/app/Repositories/ReservationRepository.php
+++ b/app/Repositories/ReservationRepository.php
@@ -79,6 +79,17 @@ class ReservationRepository
         $reservation->update(['reminder_sent_at' => now()]);
     }
 
+    public function findCompletable(): Collection
+    {
+        return Reservation::where('status', Reservation::STATUS_CONFIRMED)
+            ->whereRaw(
+                'CAST(date AS timestamp) + end_time < ?',
+                [now()]
+            )
+            ->with('table')
+            ->get();
+    }
+
     public function findDueForReminder(int $reminderHours): Collection
     {
         $now = now();

--- a/routes/console.php
+++ b/routes/console.php
@@ -1,6 +1,8 @@
 <?php
 
+use App\Jobs\AutoCompleteReservationsJob;
 use App\Jobs\SendReservationRemindersJob;
 use Illuminate\Support\Facades\Schedule;
 
 Schedule::job(new SendReservationRemindersJob())->everyThirtyMinutes();
+Schedule::job(new AutoCompleteReservationsJob())->everyFifteenMinutes();

--- a/tests/Feature/AutoCompleteReservationsJobTest.php
+++ b/tests/Feature/AutoCompleteReservationsJobTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Jobs\AutoCompleteReservationsJob;
+use App\Models\Reservation;
+use App\Repositories\ReservationRepository;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AutoCompleteReservationsJobTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed(\Database\Seeders\RoleSeeder::class);
+        $this->seed(\Database\Seeders\RestaurantSettingSeeder::class);
+    }
+
+    private function runJob(): void
+    {
+        (new AutoCompleteReservationsJob())->handle(
+            app(ReservationRepository::class),
+        );
+    }
+
+    public function test_completes_confirmed_reservation_past_end_time(): void
+    {
+        $reservation = Reservation::factory()->confirmed()->create([
+            'date' => now()->subDay()->format('Y-m-d'),
+            'start_time' => '18:00:00',
+            'end_time' => '20:00:00',
+        ]);
+
+        $this->runJob();
+
+        $this->assertSame(Reservation::STATUS_COMPLETED, $reservation->fresh()->status);
+    }
+
+    public function test_does_not_complete_confirmed_reservation_still_in_progress(): void
+    {
+        $reservation = Reservation::factory()->confirmed()->create([
+            'date' => now()->addDay()->format('Y-m-d'),
+            'start_time' => '18:00:00',
+            'end_time' => '20:00:00',
+        ]);
+
+        $this->runJob();
+
+        $this->assertSame(Reservation::STATUS_CONFIRMED, $reservation->fresh()->status);
+    }
+
+    public function test_does_not_complete_reservations_with_non_confirmed_statuses(): void
+    {
+        $yesterday = now()->subDay()->format('Y-m-d');
+
+        $pending = Reservation::factory()->pending()->create([
+            'date' => $yesterday,
+            'end_time' => '20:00:00',
+        ]);
+
+        $cancelled = Reservation::factory()->cancelled()->create([
+            'date' => $yesterday,
+            'end_time' => '20:00:00',
+        ]);
+
+        $expired = Reservation::factory()->expired()->create([
+            'date' => $yesterday,
+            'end_time' => '20:00:00',
+        ]);
+
+        $this->runJob();
+
+        $this->assertSame(Reservation::STATUS_PENDING, $pending->fresh()->status);
+        $this->assertSame(Reservation::STATUS_CANCELLED, $cancelled->fresh()->status);
+        $this->assertSame(Reservation::STATUS_EXPIRED, $expired->fresh()->status);
+    }
+
+    public function test_completes_multiple_reservations_in_single_run(): void
+    {
+        $yesterday = now()->subDay()->format('Y-m-d');
+
+        $first = Reservation::factory()->confirmed()->create([
+            'date' => $yesterday,
+            'end_time' => '20:00:00',
+        ]);
+
+        $second = Reservation::factory()->confirmed()->create([
+            'date' => $yesterday,
+            'end_time' => '22:00:00',
+        ]);
+
+        $this->runJob();
+
+        $this->assertSame(Reservation::STATUS_COMPLETED, $first->fresh()->status);
+        $this->assertSame(Reservation::STATUS_COMPLETED, $second->fresh()->status);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ReservationRepository::findCompletable()` to query confirmed reservations past their end time
- Add `AutoCompleteReservationsJob` that transitions completable reservations to `completed` status
- Schedule the job to run every 15 minutes via `routes/console.php`
- Add 4 feature tests covering completion, in-progress skip, non-confirmed skip, and batch processing

## Test plan
- [x] Completes confirmed reservation with past end time
- [x] Skips confirmed reservation still in progress
- [x] Skips non-confirmed statuses (pending, cancelled, expired)
- [x] Completes multiple reservations in a single run
- [x] All existing tests remain green

Closes #75