### PR TITLE
Add Filament ReservationResource with no-show action

### DIFF
--- a/app/Filament/Resources/ReservationResource.php
+++ b/app/Filament/Resources/ReservationResource.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\ReservationResource\Pages;
+use App\Models\Payment;
+use App\Models\Reservation;
+use App\Services\ReservationService;
+use BackedEnum;
+use Filament\Actions\Action;
+use Filament\Resources\Resource;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+
+class ReservationResource extends Resource
+{
+    protected static ?string $model = Reservation::class;
+
+    protected static string | BackedEnum | null $navigationIcon = Heroicon::OutlinedCalendarDays;
+
+    protected static ?string $navigationLabel = 'Reservas';
+
+    protected static ?string $modelLabel = 'Reserva';
+
+    protected static ?string $pluralModelLabel = 'Reservas';
+
+    public static function canCreate(): bool
+    {
+        return false;
+    }
+
+    public static function table(Tables\Table $table): Tables\Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('client_name')
+                    ->label('Cliente')
+                    ->getStateUsing(fn (Reservation $record): string => $record->user?->name ?? $record->guest_name ?? '-')
+                    ->searchable(query: function ($query, string $search): void {
+                        $query->where(function ($query) use ($search) {
+                            $query->whereHas('user', fn ($q) => $q->where('name', 'ilike', "%{$search}%"))
+                                ->orWhere('guest_name', 'ilike', "%{$search}%");
+                        });
+                    }),
+
+                TextColumn::make('table.name')
+                    ->label('Mesa')
+                    ->sortable(),
+
+                TextColumn::make('seats_requested')
+                    ->label('Comensales')
+                    ->sortable(),
+
+                TextColumn::make('date')
+                    ->label('Fecha')
+                    ->date('d/m/Y')
+                    ->sortable(),
+
+                TextColumn::make('start_time')
+                    ->label('Inicio')
+                    ->time('H:i'),
+
+                TextColumn::make('end_time')
+                    ->label('Fin')
+                    ->time('H:i'),
+
+                TextColumn::make('status')
+                    ->label('Estado')
+                    ->badge()
+                    ->formatStateUsing(fn (string $state): string => self::statusLabel($state))
+                    ->color(fn (string $state): string => self::statusColor($state))
+                    ->sortable(),
+
+                TextColumn::make('payment.status')
+                    ->label('Pago')
+                    ->badge()
+                    ->formatStateUsing(fn (?string $state): string => self::paymentLabel($state))
+                    ->color(fn (?string $state): string => self::paymentColor($state)),
+            ])
+            ->defaultSort('date', 'desc')
+            ->filters([
+                SelectFilter::make('status')
+                    ->label('Estado')
+                    ->options([
+                        Reservation::STATUS_PENDING => 'Pendiente',
+                        Reservation::STATUS_CONFIRMED => 'Confirmada',
+                        Reservation::STATUS_COMPLETED => 'Completada',
+                        Reservation::STATUS_CANCELLED => 'Cancelada',
+                        Reservation::STATUS_NO_SHOW => 'No show',
+                        Reservation::STATUS_EXPIRED => 'Expirada',
+                    ]),
+
+                SelectFilter::make('payment_status')
+                    ->label('Estado de pago')
+                    ->relationship('payment', 'status')
+                    ->options([
+                        Payment::STATUS_PENDING => 'Pendiente',
+                        Payment::STATUS_SUCCEEDED => 'Pagado',
+                        Payment::STATUS_FAILED => 'Fallido',
+                        Payment::STATUS_REFUNDED => 'Reembolsado',
+                        Payment::STATUS_PARTIALLY_REFUNDED => 'Reembolso parcial',
+                    ]),
+            ])
+            ->recordActions([
+                Action::make('no_show')
+                    ->label('No show')
+                    ->icon(Heroicon::OutlinedXCircle)
+                    ->color('danger')
+                    ->requiresConfirmation()
+                    ->modalHeading('Marcar como No show')
+                    ->modalDescription('Esta accion cambiara el estado de la reserva a "No show". Esta seguro?')
+                    ->visible(fn (Reservation $record): bool => $record->status === Reservation::STATUS_COMPLETED)
+                    ->action(fn (Reservation $record) => app(ReservationService::class)->markAsNoShow($record)),
+            ]);
+    }
+
+    private static function statusLabel(string $state): string
+    {
+        return match ($state) {
+            Reservation::STATUS_PENDING => 'Pendiente',
+            Reservation::STATUS_CONFIRMED => 'Confirmada',
+            Reservation::STATUS_COMPLETED => 'Completada',
+            Reservation::STATUS_CANCELLED => 'Cancelada',
+            Reservation::STATUS_NO_SHOW => 'No show',
+            Reservation::STATUS_EXPIRED => 'Expirada',
+            default => $state,
+        };
+    }
+
+    private static function statusColor(string $state): string
+    {
+        return match ($state) {
+            Reservation::STATUS_PENDING => 'warning',
+            Reservation::STATUS_CONFIRMED => 'info',
+            Reservation::STATUS_COMPLETED => 'success',
+            Reservation::STATUS_CANCELLED => 'gray',
+            Reservation::STATUS_NO_SHOW => 'danger',
+            Reservation::STATUS_EXPIRED => 'gray',
+            default => 'gray',
+        };
+    }
+
+    private static function paymentLabel(?string $state): string
+    {
+        return match ($state) {
+            Payment::STATUS_PENDING => 'Pendiente',
+            Payment::STATUS_SUCCEEDED => 'Pagado',
+            Payment::STATUS_FAILED => 'Fallido',
+            Payment::STATUS_REFUNDED => 'Reembolsado',
+            Payment::STATUS_PARTIALLY_REFUNDED => 'Reembolso parcial',
+            default => 'Sin pago',
+        };
+    }
+
+    private static function paymentColor(?string $state): string
+    {
+        return match ($state) {
+            Payment::STATUS_PENDING => 'warning',
+            Payment::STATUS_SUCCEEDED => 'success',
+            Payment::STATUS_FAILED => 'danger',
+            Payment::STATUS_REFUNDED => 'info',
+            Payment::STATUS_PARTIALLY_REFUNDED => 'info',
+            default => 'gray',
+        };
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListReservations::route('/'),
+        ];
+    }
+}

--- a/app/Filament/Resources/ReservationResource/Pages/ListReservations.php
+++ b/app/Filament/Resources/ReservationResource/Pages/ListReservations.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\ReservationResource\Pages;
+
+use App\Filament\Resources\ReservationResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListReservations extends ListRecords
+{
+    protected static string $resource = ReservationResource::class;
+}

--- a/app/Services/ReservationService.php
+++ b/app/Services/ReservationService.php
@@ -200,6 +200,19 @@ class ReservationService
         return $reservation;
     }
 
+    public function markAsNoShow(Reservation $reservation): Reservation
+    {
+        if ($reservation->status !== Reservation::STATUS_COMPLETED) {
+            throw ValidationException::withMessages([
+                'reservation' => ['Solo las reservas completadas pueden marcarse como no show.'],
+            ]);
+        }
+
+        $this->reservationRepository->updateStatus($reservation, Reservation::STATUS_NO_SHOW);
+
+        return $reservation->fresh();
+    }
+
     public function find(int $id): ?Reservation
     {
         return $this->reservationRepository->find($id);

--- a/tests/Feature/ReservationResourceTest.php
+++ b/tests/Feature/ReservationResourceTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Filament\Resources\ReservationResource\Pages\ListReservations;
+use App\Models\Reservation;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+use Tests\Traits\CreatesUsers;
+
+class ReservationResourceTest extends TestCase
+{
+    use RefreshDatabase;
+    use CreatesUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed(\Database\Seeders\RoleSeeder::class);
+        $this->seed(\Database\Seeders\RestaurantSettingSeeder::class);
+    }
+
+    public function test_admin_can_see_reservations_list(): void
+    {
+        $admin = $this->adminUser();
+
+        $reservation = Reservation::factory()->confirmed()->create();
+
+        Livewire::actingAs($admin)
+            ->test(ListReservations::class)
+            ->assertCanSeeTableRecords([$reservation]);
+    }
+
+    public function test_no_show_action_is_visible_for_completed_reservations(): void
+    {
+        $admin = $this->adminUser();
+
+        $reservation = Reservation::factory()->create([
+            'status' => Reservation::STATUS_COMPLETED,
+        ]);
+
+        Livewire::actingAs($admin)
+            ->test(ListReservations::class)
+            ->assertTableActionVisible('no_show', $reservation);
+    }
+
+    public function test_no_show_action_is_hidden_for_non_completed_reservations(): void
+    {
+        $admin = $this->adminUser();
+
+        $confirmed = Reservation::factory()->confirmed()->create();
+        $pending = Reservation::factory()->pending()->create();
+        $cancelled = Reservation::factory()->cancelled()->create();
+
+        $component = Livewire::actingAs($admin)
+            ->test(ListReservations::class);
+
+        $component->assertTableActionHidden('no_show', $confirmed);
+        $component->assertTableActionHidden('no_show', $pending);
+        $component->assertTableActionHidden('no_show', $cancelled);
+    }
+
+    public function test_no_show_action_changes_status_to_no_show(): void
+    {
+        $admin = $this->adminUser();
+
+        $reservation = Reservation::factory()->create([
+            'status' => Reservation::STATUS_COMPLETED,
+        ]);
+
+        Livewire::actingAs($admin)
+            ->test(ListReservations::class)
+            ->callTableAction('no_show', $reservation);
+
+        $this->assertSame(Reservation::STATUS_NO_SHOW, $reservation->fresh()->status);
+    }
+}

--- a/tests/Unit/ReservationServiceTest.php
+++ b/tests/Unit/ReservationServiceTest.php
@@ -234,6 +234,54 @@ class ReservationServiceTest extends TestCase
         $this->service->cancel($reservation);
     }
 
+    // ── markAsNoShow ─────────────────────────────────────────
+
+    public function test_mark_as_no_show_changes_completed_to_no_show(): void
+    {
+        /** @var Reservation&MockInterface $reservation */
+        $reservation = Mockery::mock(Reservation::class)->makePartial();
+        $reservation->status = Reservation::STATUS_COMPLETED;
+
+        $this->reservationRepository
+            ->shouldReceive('updateStatus')
+            ->with($reservation, Reservation::STATUS_NO_SHOW)
+            ->once();
+
+        /** @var Reservation&MockInterface $freshReservation */
+        $freshReservation = Mockery::mock(Reservation::class)->makePartial();
+        $freshReservation->status = Reservation::STATUS_NO_SHOW;
+        $reservation->shouldReceive('fresh')->once()->andReturn($freshReservation);
+
+        $result = $this->service->markAsNoShow($reservation);
+
+        $this->assertEquals(Reservation::STATUS_NO_SHOW, $result->status);
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('nonCompletedStatusProvider')]
+    public function test_mark_as_no_show_rejects_non_completed_status(string $status): void
+    {
+        /** @var Reservation&MockInterface $reservation */
+        $reservation = Mockery::mock(Reservation::class)->makePartial();
+        $reservation->status = $status;
+
+        $this->expectException(ValidationException::class);
+
+        $this->service->markAsNoShow($reservation);
+    }
+
+    public static function nonCompletedStatusProvider(): array
+    {
+        return [
+            'pending' => [Reservation::STATUS_PENDING],
+            'confirmed' => [Reservation::STATUS_CONFIRMED],
+            'cancelled' => [Reservation::STATUS_CANCELLED],
+            'expired' => [Reservation::STATUS_EXPIRED],
+            'no_show' => [Reservation::STATUS_NO_SHOW],
+        ];
+    }
+
+    // ── cancel (same day) ───────────────────────────────────
+
     public function test_cancel_same_day_applies_partial_refund(): void
     {
         /** @var Reservation&MockInterface $reservation */


### PR DESCRIPTION
## Summary
- Add `ReservationService::markAsNoShow()` to transition completed reservations to `no_show` status
- Add read-only `ReservationResource` in Filament with status and payment badges, filters, and search
- Add "No show" record action visible only on completed reservations with confirmation dialog
- Add unit tests for `markAsNoShow()` (happy path + data provider for rejected statuses)
- Add feature tests for the Filament resource (listing, action visibility, state transition)

## Test plan
- [x] `markAsNoShow()` transitions completed reservation to no_show
- [x] `markAsNoShow()` rejects pending, confirmed, cancelled, expired, and no_show statuses
- [x] Admin can see reservations list in Filament
- [x] No-show action visible only for completed reservations
- [x] No-show action hidden for non-completed reservations
- [x] No-show action changes status to no_show
- [x] Full test suite passes (188 tests)

Closes #77