### PR TITLE
Add restaurant opening hours to settings with public endpoint

### DIFF
--- a/app/DTOs/UpdateRestaurantSettingDTO.php
+++ b/app/DTOs/UpdateRestaurantSettingDTO.php
@@ -11,6 +11,8 @@ readonly class UpdateRestaurantSettingDTO
         public ?int $default_reservation_duration_minutes = null,
         public ?int $reminder_hours_before = null,
         public ?int $time_slot_interval_minutes = null,
+        public ?string $opening_time = null,
+        public ?string $closing_time = null,
         private array $presentFields = [],
     ) {}
 
@@ -23,6 +25,8 @@ readonly class UpdateRestaurantSettingDTO
             default_reservation_duration_minutes: $validated['default_reservation_duration_minutes'] ?? null,
             reminder_hours_before: $validated['reminder_hours_before'] ?? null,
             time_slot_interval_minutes: $validated['time_slot_interval_minutes'] ?? null,
+            opening_time: $validated['opening_time'] ?? null,
+            closing_time: $validated['closing_time'] ?? null,
             presentFields: array_keys($validated),
         );
     }

--- a/app/Filament/Pages/ManageRestaurantSettings.php
+++ b/app/Filament/Pages/ManageRestaurantSettings.php
@@ -7,6 +7,7 @@ use BackedEnum;
 use Filament\Actions\Action;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\TimePicker;
 use Filament\Notifications\Notification;
 use Filament\Pages\Page;
 use Filament\Schemas\Components\Actions;
@@ -56,6 +57,22 @@ class ManageRestaurantSettings extends Page
     {
         return $schema
             ->schema([
+                Section::make('Horario de Apertura')
+                    ->schema([
+                        TimePicker::make('opening_time')
+                            ->label('Hora de apertura')
+                            ->helperText('Hora a la que el restaurante abre para reservas.')
+                            ->required()
+                            ->seconds(false),
+
+                        TimePicker::make('closing_time')
+                            ->label('Hora de cierre')
+                            ->helperText('Hora a la que el restaurante cierra. Las reservas deben iniciar antes de este horario.')
+                            ->required()
+                            ->seconds(false),
+                    ])
+                    ->columns(2),
+
                 Section::make('Deposito y Pagos')
                     ->schema([
                         TextInput::make('deposit_per_person')

--- a/app/Http/Controllers/PublicSettingController.php
+++ b/app/Http/Controllers/PublicSettingController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Resources\PublicRestaurantSettingResource;
+use App\Services\RestaurantSettingService;
+
+class PublicSettingController extends Controller
+{
+    public function __invoke(RestaurantSettingService $service): PublicRestaurantSettingResource
+    {
+        return new PublicRestaurantSettingResource($service->get());
+    }
+}

--- a/app/Http/Requests/UpdateRestaurantSettingRequest.php
+++ b/app/Http/Requests/UpdateRestaurantSettingRequest.php
@@ -21,6 +21,31 @@ class UpdateRestaurantSettingRequest extends FormRequest
             'default_reservation_duration_minutes' => ['sometimes', 'integer', 'min:15', 'max:480'],
             'reminder_hours_before'               => ['sometimes', 'integer', 'min:1', 'max:168'],
             'time_slot_interval_minutes'          => ['sometimes', 'integer', Rule::in([15, 30, 45, 60])],
+            'opening_time'                        => ['sometimes', 'date_format:H:i'],
+            'closing_time'                        => ['sometimes', 'date_format:H:i'],
         ];
+    }
+
+    public function after(): array
+    {
+        return [
+            function ($validator) {
+                $settings = $this->existingSettings();
+                $opening = $this->input('opening_time', $settings->opening_time);
+                $closing = $this->input('closing_time', $settings->closing_time);
+
+                $openingMinutes = (int) substr($opening, 0, 2) * 60 + (int) substr($opening, 3, 2);
+                $closingMinutes = (int) substr($closing, 0, 2) * 60 + (int) substr($closing, 3, 2);
+
+                if ($openingMinutes >= $closingMinutes) {
+                    $validator->errors()->add('opening_time', 'La hora de apertura debe ser anterior a la hora de cierre.');
+                }
+            },
+        ];
+    }
+
+    private function existingSettings(): \App\Models\RestaurantSetting
+    {
+        return \App\Models\RestaurantSetting::firstOrFail();
     }
 }

--- a/app/Http/Resources/PublicRestaurantSettingResource.php
+++ b/app/Http/Resources/PublicRestaurantSettingResource.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class PublicRestaurantSettingResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'opening_time'              => substr($this->opening_time, 0, 5),
+            'closing_time'              => substr($this->closing_time, 0, 5),
+            'time_slot_interval_minutes' => $this->time_slot_interval_minutes,
+        ];
+    }
+}

--- a/app/Http/Resources/RestaurantSettingResource.php
+++ b/app/Http/Resources/RestaurantSettingResource.php
@@ -16,6 +16,8 @@ class RestaurantSettingResource extends JsonResource
             'default_reservation_duration_minutes'  => $this->default_reservation_duration_minutes,
             'reminder_hours_before'                 => $this->reminder_hours_before,
             'time_slot_interval_minutes'            => $this->time_slot_interval_minutes,
+            'opening_time'                          => substr($this->opening_time, 0, 5),
+            'closing_time'                          => substr($this->closing_time, 0, 5),
         ];
     }
 }

--- a/app/Models/RestaurantSetting.php
+++ b/app/Models/RestaurantSetting.php
@@ -13,6 +13,8 @@ class RestaurantSetting extends Model
         'default_reservation_duration_minutes',
         'reminder_hours_before',
         'time_slot_interval_minutes',
+        'opening_time',
+        'closing_time',
     ];
 
     protected function casts(): array

--- a/app/Services/ReservationService.php
+++ b/app/Services/ReservationService.php
@@ -11,6 +11,7 @@ use App\Notifications\ReservationConfirmedNotification;
 use App\Notifications\ReservationExpiredRefundNotification;
 use App\Models\Payment;
 use App\Models\Reservation;
+use App\Models\RestaurantSetting;
 use App\Repositories\ReservationRepository;
 use App\Repositories\RestaurantSettingRepository;
 use App\Repositories\TableRepository;
@@ -66,16 +67,18 @@ class ReservationService
 
             $settings = $this->settingRepository->get();
 
+            $endTime = Carbon::parse($dto->start_time)
+                ->addMinutes($settings->default_reservation_duration_minutes)
+                ->format('H:i:s');
+
+            $this->validateBusinessHours($dto->start_time, $endTime, $settings);
+
             $startTimeMinutes = Carbon::parse($dto->start_time)->minute;
             if ($startTimeMinutes % $settings->time_slot_interval_minutes !== 0) {
                 throw ValidationException::withMessages([
                     'start_time' => ["La hora de inicio debe estar alineada a intervalos de {$settings->time_slot_interval_minutes} minutos."],
                 ]);
             }
-
-            $endTime = Carbon::parse($dto->start_time)
-                ->addMinutes($settings->default_reservation_duration_minutes)
-                ->format('H:i:s');
 
             if ($this->reservationRepository->hasOverlappingReservation(
                 $dto->table_id, $dto->date, $dto->start_time, $endTime
@@ -240,6 +243,12 @@ class ReservationService
 
         $settings = $this->settingRepository->get();
 
+        $endTime = Carbon::parse($dto->start_time)
+            ->addMinutes($settings->default_reservation_duration_minutes)
+            ->format('H:i:s');
+
+        $this->validateBusinessHours($dto->start_time, $endTime, $settings);
+
         $startTimeMinutes = Carbon::parse($dto->start_time)->minute;
         if ($startTimeMinutes % $settings->time_slot_interval_minutes !== 0) {
             throw ValidationException::withMessages([
@@ -247,10 +256,23 @@ class ReservationService
             ]);
         }
 
-        $endTime = Carbon::parse($dto->start_time)
-            ->addMinutes($settings->default_reservation_duration_minutes)
-            ->format('H:i:s');
-
         return $this->tableRepository->findAvailable($dto->seats_requested, $dto->date, $dto->start_time, $endTime);
+    }
+
+    private function validateBusinessHours(string $startTime, string $endTime, RestaurantSetting $settings): void
+    {
+        $opening = substr($settings->opening_time, 0, 5);
+        $closing = $settings->closing_time;
+
+        if ($startTime < $opening || $endTime > $closing) {
+            throw ValidationException::withMessages([
+                'start_time' => ["La reserva debe estar dentro del horario de apertura: {$opening} - {$this->formatTime($closing)}."],
+            ]);
+        }
+    }
+
+    private function formatTime(string $time): string
+    {
+        return substr($time, 0, 5);
     }
 }

--- a/database/migrations/2026_04_12_132405_add_opening_hours_to_restaurant_settings_table.php
+++ b/database/migrations/2026_04_12_132405_add_opening_hours_to_restaurant_settings_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('restaurant_settings', function (Blueprint $table) {
+            $table->time('opening_time')->default('09:00:00')->after('time_slot_interval_minutes');
+            $table->time('closing_time')->default('23:00:00')->after('opening_time');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('restaurant_settings', function (Blueprint $table) {
+            $table->dropColumn(['opening_time', 'closing_time']);
+        });
+    }
+};

--- a/database/seeders/RestaurantSettingSeeder.php
+++ b/database/seeders/RestaurantSettingSeeder.php
@@ -16,6 +16,8 @@ class RestaurantSettingSeeder extends Seeder
             'default_reservation_duration_minutes' => 120,
             'reminder_hours_before' => 24,
             'time_slot_interval_minutes' => 30,
+            'opening_time' => '09:00',
+            'closing_time' => '23:00',
         ]);
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -10,6 +10,7 @@ use App\Http\Controllers\Client\GuestReservationController;
 use App\Http\Controllers\Client\MenuItemController as ClientMenuItemController;
 use App\Http\Controllers\Client\PreOrderController;
 use App\Http\Controllers\Client\ReservationController as ClientReservationController;
+use App\Http\Controllers\PublicSettingController;
 use App\Http\Controllers\StripeWebhookController;
 use Illuminate\Support\Facades\Route;
 
@@ -27,6 +28,7 @@ Route::prefix('auth')->group(function () {
     });
 });
 
+Route::get('settings/public', PublicSettingController::class);
 Route::get('menu-items', [ClientMenuItemController::class, 'index']);
 Route::get('reservations/available-tables', [ClientReservationController::class, 'availableTables']);
 Route::post('guest/reservations', [GuestReservationController::class, 'store']);

--- a/tests/Feature/ReservationTest.php
+++ b/tests/Feature/ReservationTest.php
@@ -542,4 +542,54 @@ class ReservationTest extends TestCase
             'status' => Reservation::STATUS_CONFIRMED,
         ]);
     }
+
+    // ── Business hours validation ───────────────────────────
+
+    public function test_hold_rejects_start_time_before_opening(): void
+    {
+        $this->paymentServiceMock->shouldNotReceive('createPaymentIntent');
+
+        RestaurantSetting::first()->update(['opening_time' => '12:00', 'closing_time' => '22:00']);
+
+        $response = $this->actingAs($this->clientUser())
+            ->postJson('/api/reservations', $this->holdData([
+                'start_time' => '11:00',
+            ]));
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['start_time']);
+    }
+
+    public function test_hold_rejects_reservation_ending_after_closing(): void
+    {
+        $this->paymentServiceMock->shouldNotReceive('createPaymentIntent');
+
+        RestaurantSetting::first()->update([
+            'opening_time' => '09:00',
+            'closing_time' => '22:00',
+            'default_reservation_duration_minutes' => 120,
+        ]);
+
+        $response = $this->actingAs($this->clientUser())
+            ->postJson('/api/reservations', $this->holdData([
+                'start_time' => '21:00',
+            ]));
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['start_time']);
+    }
+
+    public function test_available_tables_rejects_time_outside_business_hours(): void
+    {
+        RestaurantSetting::first()->update(['opening_time' => '12:00', 'closing_time' => '22:00']);
+
+        $response = $this->getJson('/api/reservations/available-tables?' . http_build_query([
+            'date' => now()->addDays(3)->format('Y-m-d'),
+            'start_time' => '11:00',
+            'seats_requested' => 2,
+        ]));
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['start_time']);
+    }
 }

--- a/tests/Feature/RestaurantSettingTest.php
+++ b/tests/Feature/RestaurantSettingTest.php
@@ -35,6 +35,8 @@ class RestaurantSettingTest extends TestCase
                     'default_reservation_duration_minutes',
                     'reminder_hours_before',
                     'time_slot_interval_minutes',
+                    'opening_time',
+                    'closing_time',
                 ],
             ]);
     }
@@ -140,5 +142,97 @@ class RestaurantSettingTest extends TestCase
 
         $this->patchJson('/api/admin/settings', ['time_slot_interval_minutes' => 15])
             ->assertStatus(401);
+    }
+
+    // ── Opening Hours ───────────────────────────────────────
+
+    public function test_admin_can_update_opening_hours(): void
+    {
+        $response = $this->actingAs($this->adminUser())
+            ->patchJson('/api/admin/settings', [
+                'opening_time' => '10:00',
+                'closing_time' => '22:00',
+            ]);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.opening_time', '10:00')
+            ->assertJsonPath('data.closing_time', '22:00');
+    }
+
+    public function test_update_rejects_opening_time_after_closing_time(): void
+    {
+        $response = $this->actingAs($this->adminUser())
+            ->patchJson('/api/admin/settings', [
+                'opening_time' => '22:00',
+                'closing_time' => '10:00',
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['opening_time']);
+    }
+
+    public function test_update_rejects_opening_time_equal_to_closing_time(): void
+    {
+        $response = $this->actingAs($this->adminUser())
+            ->patchJson('/api/admin/settings', [
+                'opening_time' => '12:00',
+                'closing_time' => '12:00',
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['opening_time']);
+    }
+
+    public function test_partial_update_validates_against_existing_hours(): void
+    {
+        RestaurantSetting::first()->update(['opening_time' => '10:00', 'closing_time' => '22:00']);
+
+        $response = $this->actingAs($this->adminUser())
+            ->patchJson('/api/admin/settings', [
+                'closing_time' => '09:00',
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['opening_time']);
+    }
+
+    public function test_update_rejects_invalid_time_format(): void
+    {
+        $response = $this->actingAs($this->adminUser())
+            ->patchJson('/api/admin/settings', [
+                'opening_time' => '9am',
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['opening_time']);
+    }
+
+    // ── Public Endpoint ─────────────────────────────────────
+
+    public function test_public_endpoint_returns_schedule_settings(): void
+    {
+        $response = $this->getJson('/api/settings/public');
+
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'data' => [
+                    'opening_time',
+                    'closing_time',
+                    'time_slot_interval_minutes',
+                ],
+            ])
+            ->assertJsonPath('data.opening_time', '09:00')
+            ->assertJsonPath('data.closing_time', '23:00')
+            ->assertJsonPath('data.time_slot_interval_minutes', 30);
+    }
+
+    public function test_public_endpoint_does_not_expose_sensitive_settings(): void
+    {
+        $response = $this->getJson('/api/settings/public');
+
+        $response->assertStatus(200)
+            ->assertJsonMissing(['deposit_per_person'])
+            ->assertJsonMissing(['cancellation_deadline_hours'])
+            ->assertJsonMissing(['refund_percentage']);
     }
 }


### PR DESCRIPTION
## Summary

- Add `opening_time` and `closing_time` columns to `restaurant_settings` (migration + model + seeder)
- Add "Horario de Apertura" section with TimePickers in Filament settings page
- Add `GET /api/settings/public` endpoint (no auth) exposing `opening_time`, `closing_time`, and `time_slot_interval_minutes`
- Validate reservation times fall within business hours in `ReservationService::hold()` and `suggestAvailableTables()`
- Update `UpdateRestaurantSettingDTO`, `UpdateRestaurantSettingRequest` (with cross-field validation), and `RestaurantSettingResource`

## Test plan

- [x] Admin can update opening/closing hours via API
- [x] Rejects opening_time >= closing_time (both full and partial updates)
- [x] Rejects invalid time format
- [x] Public endpoint returns only schedule-related settings without auth
- [x] Public endpoint does not expose sensitive settings (deposit, refund, etc.)
- [x] Hold rejects start_time before opening
- [x] Hold rejects reservation ending after closing
- [x] Available tables rejects time outside business hours
- [x] All 198 existing tests pass (no regressions)

Closes #85