### PR TITLE
Add user profile endpoints with is_guest support

### DIFF
--- a/app/DTOs/UpdatePasswordDTO.php
+++ b/app/DTOs/UpdatePasswordDTO.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\DTOs;
+
+readonly class UpdatePasswordDTO
+{
+    public function __construct(
+        public int $user_id,
+        public string $password,
+    ) {}
+}

--- a/app/DTOs/UpdateProfileDTO.php
+++ b/app/DTOs/UpdateProfileDTO.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\DTOs;
+
+readonly class UpdateProfileDTO
+{
+    public function __construct(
+        public int $user_id,
+        public ?string $name = null,
+        public ?string $email = null,
+        public ?string $phone = null,
+        private array $presentFields = [],
+    ) {}
+
+    public static function fromValidated(int $userId, array $validated): self
+    {
+        return new self(
+            user_id: $userId,
+            name: $validated['name'] ?? null,
+            email: $validated['email'] ?? null,
+            phone: $validated['phone'] ?? null,
+            presentFields: array_keys($validated),
+        );
+    }
+
+    public function userData(): array
+    {
+        return array_filter(
+            ['name' => $this->name, 'email' => $this->email],
+            fn (mixed $value, string $key) => in_array($key, $this->presentFields),
+            ARRAY_FILTER_USE_BOTH,
+        );
+    }
+
+    public function hasPhone(): bool
+    {
+        return in_array('phone', $this->presentFields);
+    }
+}

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\DTOs\UpdatePasswordDTO;
+use App\DTOs\UpdateProfileDTO;
+use App\Http\Requests\UpdatePasswordRequest;
+use App\Http\Requests\UpdateProfileRequest;
+use App\Http\Resources\UserResource;
+use App\Services\ProfileService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class ProfileController extends Controller
+{
+    public function __construct(private ProfileService $service) {}
+
+    public function show(Request $request): UserResource
+    {
+        return new UserResource($this->service->get($request->user()->id));
+    }
+
+    public function update(UpdateProfileRequest $request): UserResource
+    {
+        $user = $this->service->update(
+            UpdateProfileDTO::fromValidated($request->user()->id, $request->validated())
+        );
+
+        return new UserResource($user);
+    }
+
+    public function updatePassword(UpdatePasswordRequest $request): JsonResponse
+    {
+        $this->service->updatePassword(new UpdatePasswordDTO(
+            user_id: $request->user()->id,
+            password: $request->validated('password'),
+        ));
+
+        return response()->json([
+            'message' => 'Contrasena actualizada correctamente.',
+        ]);
+    }
+}

--- a/app/Http/Requests/UpdatePasswordRequest.php
+++ b/app/Http/Requests/UpdatePasswordRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rules\Password;
+
+class UpdatePasswordRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'current_password' => ['required', 'string', 'current_password'],
+            'password'         => ['required', 'string', Password::defaults(), 'confirmed'],
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateProfileRequest.php
+++ b/app/Http/Requests/UpdateProfileRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateProfileRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name'  => ['sometimes', 'string', 'max:255'],
+            'email' => ['sometimes', 'string', 'email', 'max:255', Rule::unique('users')->ignore($this->user()->id)],
+            'phone' => ['sometimes', 'nullable', 'string', 'max:20'],
+        ];
+    }
+}

--- a/app/Http/Resources/UserResource.php
+++ b/app/Http/Resources/UserResource.php
@@ -10,10 +10,12 @@ class UserResource extends JsonResource
     public function toArray(Request $request): array
     {
         return [
-            'id'    => $this->id,
-            'name'  => $this->name,
-            'email' => $this->email,
-            'role'  => $this->getRoleNames()->first(),
+            'id'       => $this->id,
+            'name'     => $this->name,
+            'email'    => $this->email,
+            'phone'    => $this->clientProfile?->phone,
+            'role'     => $this->getRoleNames()->first(),
+            'is_guest' => $this->isGuest(),
         ];
     }
 }

--- a/app/Services/ProfileService.php
+++ b/app/Services/ProfileService.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Services;
+
+use App\DTOs\UpdatePasswordDTO;
+use App\DTOs\UpdateProfileDTO;
+use App\Models\User;
+
+class ProfileService
+{
+    public function get(int $userId): User
+    {
+        return User::with('clientProfile')->findOrFail($userId);
+    }
+
+    public function update(UpdateProfileDTO $dto): User
+    {
+        $user = User::with('clientProfile')->findOrFail($dto->user_id);
+
+        $userData = $dto->userData();
+        if ($userData) {
+            $user->update($userData);
+        }
+
+        if ($dto->hasPhone() && $user->clientProfile) {
+            $user->clientProfile->update(['phone' => $dto->phone]);
+        }
+
+        return $user->fresh('clientProfile');
+    }
+
+    public function updatePassword(UpdatePasswordDTO $dto): User
+    {
+        $user = User::findOrFail($dto->user_id);
+
+        $user->update(['password' => $dto->password]);
+
+        return $user;
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -10,6 +10,7 @@ use App\Http\Controllers\Client\GuestReservationController;
 use App\Http\Controllers\Client\MenuItemController as ClientMenuItemController;
 use App\Http\Controllers\Client\PreOrderController;
 use App\Http\Controllers\Client\ReservationController as ClientReservationController;
+use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\PublicSettingController;
 use App\Http\Controllers\StripeWebhookController;
 use Illuminate\Support\Facades\Route;
@@ -53,6 +54,10 @@ Route::middleware(['auth:sanctum', 'role:admin'])->prefix('admin')->group(functi
 });
 
 Route::middleware('auth:sanctum')->group(function () {
+    Route::get('profile', [ProfileController::class, 'show']);
+    Route::put('profile', [ProfileController::class, 'update']);
+    Route::put('profile/password', [ProfileController::class, 'updatePassword']);
+
     Route::prefix('reservations')->group(function () {
         Route::post('/', [ClientReservationController::class, 'store']);
         Route::get('/', [ClientReservationController::class, 'index']);

--- a/tests/Feature/ProfileTest.php
+++ b/tests/Feature/ProfileTest.php
@@ -1,0 +1,250 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\ClientProfile;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use Tests\Traits\CreatesUsers;
+
+class ProfileTest extends TestCase
+{
+    use RefreshDatabase;
+    use CreatesUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(\Database\Seeders\RoleSeeder::class);
+    }
+
+    private function clientWithProfile(): User
+    {
+        $user = $this->clientUser();
+        $user->clientProfile()->create(['phone' => '612345678']);
+
+        return $user;
+    }
+
+    // ── Show ─────────────────────────────────────────────────
+
+    public function test_client_can_view_profile(): void
+    {
+        $user = $this->clientWithProfile();
+
+        $response = $this->actingAs($user)->getJson('/api/profile');
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.id', $user->id)
+            ->assertJsonPath('data.name', $user->name)
+            ->assertJsonPath('data.email', $user->email)
+            ->assertJsonPath('data.phone', '612345678')
+            ->assertJsonPath('data.role', 'client')
+            ->assertJsonPath('data.is_guest', false);
+    }
+
+    public function test_admin_can_view_profile(): void
+    {
+        $admin = $this->adminUser();
+
+        $response = $this->actingAs($admin)->getJson('/api/profile');
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.role', 'admin')
+            ->assertJsonPath('data.phone', null)
+            ->assertJsonPath('data.is_guest', false);
+    }
+
+    public function test_guest_user_shows_is_guest_true(): void
+    {
+        $guest = User::factory()->create(['password' => null]);
+        $guest->assignRole('client');
+        $guest->clientProfile()->create([]);
+
+        $response = $this->actingAs($guest)->getJson('/api/profile');
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.is_guest', true);
+    }
+
+    public function test_unauthenticated_user_cannot_view_profile(): void
+    {
+        $this->getJson('/api/profile')->assertStatus(401);
+    }
+
+    // ── Update ───────────────────────────────────────────────
+
+    public function test_client_can_update_name(): void
+    {
+        $user = $this->clientWithProfile();
+
+        $response = $this->actingAs($user)
+            ->putJson('/api/profile', ['name' => 'Nuevo Nombre']);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.name', 'Nuevo Nombre');
+
+        $this->assertDatabaseHas('users', ['id' => $user->id, 'name' => 'Nuevo Nombre']);
+    }
+
+    public function test_client_can_update_email(): void
+    {
+        $user = $this->clientWithProfile();
+
+        $response = $this->actingAs($user)
+            ->putJson('/api/profile', ['email' => 'nuevo@example.com']);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.email', 'nuevo@example.com');
+    }
+
+    public function test_client_can_update_phone(): void
+    {
+        $user = $this->clientWithProfile();
+
+        $response = $this->actingAs($user)
+            ->putJson('/api/profile', ['phone' => '698765432']);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.phone', '698765432');
+
+        $this->assertDatabaseHas('client_profiles', ['user_id' => $user->id, 'phone' => '698765432']);
+    }
+
+    public function test_client_can_update_multiple_fields(): void
+    {
+        $user = $this->clientWithProfile();
+
+        $response = $this->actingAs($user)
+            ->putJson('/api/profile', [
+                'name' => 'Otro Nombre',
+                'email' => 'otro@example.com',
+                'phone' => '699999999',
+            ]);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.name', 'Otro Nombre')
+            ->assertJsonPath('data.email', 'otro@example.com')
+            ->assertJsonPath('data.phone', '699999999');
+    }
+
+    public function test_update_rejects_duplicate_email(): void
+    {
+        User::factory()->create(['email' => 'taken@example.com']);
+        $user = $this->clientWithProfile();
+
+        $response = $this->actingAs($user)
+            ->putJson('/api/profile', ['email' => 'taken@example.com']);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['email']);
+    }
+
+    public function test_update_allows_own_email(): void
+    {
+        $user = $this->clientWithProfile();
+
+        $response = $this->actingAs($user)
+            ->putJson('/api/profile', ['email' => $user->email]);
+
+        $response->assertStatus(200);
+    }
+
+    public function test_admin_can_update_profile(): void
+    {
+        $admin = $this->adminUser();
+
+        $response = $this->actingAs($admin)
+            ->putJson('/api/profile', ['name' => 'Admin Actualizado']);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.name', 'Admin Actualizado');
+    }
+
+    public function test_admin_phone_update_is_ignored_without_profile(): void
+    {
+        $admin = $this->adminUser();
+
+        $response = $this->actingAs($admin)
+            ->putJson('/api/profile', ['phone' => '612345678']);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.phone', null);
+    }
+
+    public function test_unauthenticated_user_cannot_update_profile(): void
+    {
+        $this->putJson('/api/profile', ['name' => 'Test'])->assertStatus(401);
+    }
+
+    // ── Update Password ─────────────────────────────────────
+
+    public function test_client_can_change_password(): void
+    {
+        $user = $this->clientWithProfile();
+
+        $response = $this->actingAs($user)
+            ->putJson('/api/profile/password', [
+                'current_password' => 'password',
+                'password' => 'NewSecure1!',
+                'password_confirmation' => 'NewSecure1!',
+            ]);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('message', 'Contrasena actualizada correctamente.');
+    }
+
+    public function test_password_change_rejects_wrong_current_password(): void
+    {
+        $user = $this->clientWithProfile();
+
+        $response = $this->actingAs($user)
+            ->putJson('/api/profile/password', [
+                'current_password' => 'wrong-password',
+                'password' => 'NewSecure1!',
+                'password_confirmation' => 'NewSecure1!',
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['current_password']);
+    }
+
+    public function test_password_change_requires_confirmation(): void
+    {
+        $user = $this->clientWithProfile();
+
+        $response = $this->actingAs($user)
+            ->putJson('/api/profile/password', [
+                'current_password' => 'password',
+                'password' => 'NewSecure1!',
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['password']);
+    }
+
+    public function test_password_change_rejects_weak_password(): void
+    {
+        $user = $this->clientWithProfile();
+
+        $response = $this->actingAs($user)
+            ->putJson('/api/profile/password', [
+                'current_password' => 'password',
+                'password' => '123',
+                'password_confirmation' => '123',
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['password']);
+    }
+
+    public function test_unauthenticated_user_cannot_change_password(): void
+    {
+        $this->putJson('/api/profile/password', [
+            'current_password' => 'password',
+            'password' => 'NewSecure1!',
+            'password_confirmation' => 'NewSecure1!',
+        ])->assertStatus(401);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `GET /api/profile`, `PUT /api/profile`, and `PUT /api/profile/password` endpoints (auth required, no role restriction)
- Expose `is_guest` and `phone` fields in `UserResource`
- `ProfileService` handles user data and client profile updates separately (user table vs client_profiles table)
- Password change requires current password verification via Laravel's `current_password` rule
- Admin users can update name/email but phone is ignored (no client profile)

## Test plan

- [x] Client can view profile with name, email, phone, role, is_guest
- [x] Admin can view profile (phone returns null)
- [x] Guest user shows is_guest as true
- [x] Client can update name, email, phone individually and together
- [x] Rejects duplicate email, allows own email
- [x] Admin can update profile, phone update ignored without client profile
- [x] Client can change password with correct current password
- [x] Rejects wrong current password, missing confirmation, weak password
- [x] Unauthenticated user cannot access any profile endpoint
- [x] Full suite: 216 tests, 688 assertions, zero regressions

Closes #86