### PR TITLE
Add is_featured filter to menu items endpoint

### DIFF
--- a/app/Filament/Resources/MenuItemResource.php
+++ b/app/Filament/Resources/MenuItemResource.php
@@ -75,6 +75,10 @@ class MenuItemResource extends Resource
                         Toggle::make('is_available')
                             ->label('Disponible')
                             ->default(true),
+
+                        Toggle::make('is_featured')
+                            ->label('Destacado')
+                            ->default(false),
                     ])
                     ->columns(2),
             ]);
@@ -113,6 +117,10 @@ class MenuItemResource extends Resource
                 IconColumn::make('is_available')
                     ->label('Disponible')
                     ->boolean(),
+
+                IconColumn::make('is_featured')
+                    ->label('Destacado')
+                    ->boolean(),
             ])
             ->filters([
                 TernaryFilter::make('is_available')
@@ -123,6 +131,11 @@ class MenuItemResource extends Resource
                 SelectFilter::make('category')
                     ->label('Categoria')
                     ->options(MenuCategory::class),
+
+                TernaryFilter::make('is_featured')
+                    ->label('Destacados')
+                    ->trueLabel('Destacados')
+                    ->falseLabel('No destacados'),
             ])
             ->recordActions([
                 Actions\EditAction::make(),

--- a/app/Http/Controllers/Client/MenuItemController.php
+++ b/app/Http/Controllers/Client/MenuItemController.php
@@ -14,6 +14,6 @@ class MenuItemController extends Controller
 
     public function index(ListMenuItemRequest $request): JsonResponse
     {
-        return MenuItemResource::collection($this->service->listForClient($request->category()))->response();
+        return MenuItemResource::collection($this->service->listForClient($request->category(), $request->featured()))->response();
     }
 }

--- a/app/Http/Requests/ListMenuItemRequest.php
+++ b/app/Http/Requests/ListMenuItemRequest.php
@@ -17,6 +17,7 @@ class ListMenuItemRequest extends FormRequest
     {
         return [
             'category' => ['sometimes', 'string', new Enum(MenuCategory::class)],
+            'featured' => ['sometimes', 'boolean'],
         ];
     }
 
@@ -25,5 +26,12 @@ class ListMenuItemRequest extends FormRequest
         $category = $this->validated('category');
 
         return $category ? MenuCategory::from($category) : null;
+    }
+
+    public function featured(): ?bool
+    {
+        return array_key_exists('featured', $this->validated())
+            ? $this->boolean('featured')
+            : null;
     }
 }

--- a/app/Http/Resources/MenuItemResource.php
+++ b/app/Http/Resources/MenuItemResource.php
@@ -16,6 +16,7 @@ class MenuItemResource extends JsonResource
             'price' => $this->price,
             'category' => $this->category->value,
             'is_available' => $this->is_available,
+            'is_featured' => $this->is_featured,
             'daily_stock' => $this->when($request->user()?->hasRole('admin'), $this->daily_stock),
             'created_at' => $this->created_at->toDateTimeString(),
         ];

--- a/app/Models/MenuItem.php
+++ b/app/Models/MenuItem.php
@@ -18,6 +18,7 @@ class MenuItem extends Model
         'price',
         'category',
         'is_available',
+        'is_featured',
         'daily_stock',
     ];
 
@@ -27,6 +28,7 @@ class MenuItem extends Model
             'price' => 'decimal:2',
             'category' => MenuCategory::class,
             'is_available' => 'boolean',
+            'is_featured' => 'boolean',
         ];
     }
 
@@ -47,6 +49,11 @@ class MenuItem extends Model
     public function scopeByCategory(Builder $query, MenuCategory $category): Builder
     {
         return $query->where('category', $category->value);
+    }
+
+    public function scopeFeatured(Builder $query): Builder
+    {
+        return $query->where('is_featured', true);
     }
 
     public function scopeInStock(Builder $query): Builder

--- a/app/Repositories/MenuItemRepository.php
+++ b/app/Repositories/MenuItemRepository.php
@@ -19,12 +19,16 @@ class MenuItemRepository
         return $query->paginate($perPage);
     }
 
-    public function paginateForClient(?MenuCategory $category = null, int $perPage = 6): LengthAwarePaginator
+    public function paginateForClient(?MenuCategory $category = null, ?bool $featured = null, int $perPage = 6): LengthAwarePaginator
     {
         $query = MenuItem::available()->inStock();
 
         if ($category) {
             $query->byCategory($category);
+        }
+
+        if ($featured !== null) {
+            $query->where('is_featured', $featured);
         }
 
         return $query->paginate($perPage);

--- a/app/Services/MenuItemService.php
+++ b/app/Services/MenuItemService.php
@@ -18,9 +18,9 @@ class MenuItemService
         return $this->repository->paginate($category, $perPage);
     }
 
-    public function listForClient(?MenuCategory $category = null, int $perPage = 6): LengthAwarePaginator
+    public function listForClient(?MenuCategory $category = null, ?bool $featured = null, int $perPage = 6): LengthAwarePaginator
     {
-        return $this->repository->paginateForClient($category, $perPage);
+        return $this->repository->paginateForClient($category, $featured, $perPage);
     }
 
     public function find(int $id): ?MenuItem

--- a/database/factories/MenuItemFactory.php
+++ b/database/factories/MenuItemFactory.php
@@ -39,4 +39,9 @@ class MenuItemFactory extends Factory
     {
         return $this->state(['daily_stock' => null]);
     }
+
+    public function featured(): static
+    {
+        return $this->state(['is_featured' => true]);
+    }
 }

--- a/database/migrations/2026_04_12_194329_add_is_featured_to_menu_items_table.php
+++ b/database/migrations/2026_04_12_194329_add_is_featured_to_menu_items_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('menu_items', function (Blueprint $table) {
+            $table->boolean('is_featured')->default(false)->after('is_available');
+            $table->index('is_featured');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('menu_items', function (Blueprint $table) {
+            $table->dropIndex(['is_featured']);
+            $table->dropColumn('is_featured');
+        });
+    }
+};

--- a/tests/Feature/ClientMenuItemTest.php
+++ b/tests/Feature/ClientMenuItemTest.php
@@ -20,7 +20,7 @@ class ClientMenuItemTest extends TestCase
 
         $response->assertStatus(200)
             ->assertJsonStructure([
-                'data' => [['id', 'name', 'description', 'price', 'category', 'is_available', 'created_at']],
+                'data' => [['id', 'name', 'description', 'price', 'category', 'is_available', 'is_featured', 'created_at']],
                 'links',
                 'meta',
             ])
@@ -89,6 +89,83 @@ class ClientMenuItemTest extends TestCase
 
         $response->assertStatus(422)
             ->assertJsonValidationErrors(['category']);
+    }
+
+    public function test_can_filter_featured_items(): void
+    {
+        MenuItem::factory()->featured()->count(2)->create();
+        MenuItem::factory()->count(3)->create();
+
+        $response = $this->getJson('/api/menu-items?featured=1');
+
+        $response->assertStatus(200)
+            ->assertJsonCount(2, 'data');
+
+        $response->json('data');
+        foreach ($response->json('data') as $item) {
+            $this->assertTrue($item['is_featured']);
+        }
+    }
+
+    public function test_can_filter_non_featured_items(): void
+    {
+        MenuItem::factory()->featured()->count(2)->create();
+        MenuItem::factory()->count(3)->create();
+
+        $response = $this->getJson('/api/menu-items?featured=0');
+
+        $response->assertStatus(200)
+            ->assertJsonCount(3, 'data');
+
+        foreach ($response->json('data') as $item) {
+            $this->assertFalse($item['is_featured']);
+        }
+    }
+
+    public function test_featured_filter_combined_with_category(): void
+    {
+        MenuItem::factory()->featured()->create(['category' => 'entrantes']);
+        MenuItem::factory()->featured()->create(['category' => 'postres']);
+        MenuItem::factory()->create(['category' => 'entrantes']);
+
+        $response = $this->getJson('/api/menu-items?category=entrantes&featured=1');
+
+        $response->assertStatus(200)
+            ->assertJsonCount(1, 'data');
+    }
+
+    public function test_featured_filter_excludes_unavailable_items(): void
+    {
+        MenuItem::factory()->featured()->create();
+        MenuItem::factory()->featured()->unavailable()->create();
+
+        $response = $this->getJson('/api/menu-items?featured=1');
+
+        $response->assertStatus(200)
+            ->assertJsonCount(1, 'data');
+    }
+
+    public function test_without_featured_filter_returns_all_available(): void
+    {
+        MenuItem::factory()->featured()->count(2)->create();
+        MenuItem::factory()->count(3)->create();
+
+        $response = $this->getJson('/api/menu-items');
+
+        $response->assertStatus(200)
+            ->assertJsonCount(5, 'data');
+    }
+
+    public function test_response_includes_is_featured_field(): void
+    {
+        MenuItem::factory()->featured()->create();
+
+        $response = $this->getJson('/api/menu-items');
+
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'data' => [['id', 'name', 'description', 'price', 'category', 'is_available', 'is_featured', 'created_at']],
+            ]);
     }
 
     public function test_response_is_paginated(): void


### PR DESCRIPTION
## Summary
- Add `is_featured` boolean column to `menu_items` table with index
- Add `featured` query parameter to `GET /api/menu-items` public endpoint
- Add toggle, icon column, and ternary filter in Filament admin panel
- Include `is_featured` in API response JSON

## Test plan
- [x] Featured filter returns only featured items (`?featured=1`)
- [x] Non-featured filter returns only non-featured items (`?featured=0`)
- [x] Combined filter with category works (`?category=entrantes&featured=1`)
- [x] Featured filter still excludes unavailable/out-of-stock items
- [x] Without filter, all available items returned (default behavior unchanged)
- [x] Response includes `is_featured` field in JSON structure
- [x] Full test suite passes (222 tests, 0 failures)

Closes #89