### PR TITLE
Fix cancel not revoking Stripe PaymentIntent on pending reservations

### DIFF
--- a/app/Services/ReservationService.php
+++ b/app/Services/ReservationService.php
@@ -178,20 +178,30 @@ class ReservationService
 
             $payment = $reservation->payment;
 
-            if ($payment && $payment->status === Payment::STATUS_SUCCEEDED) {
-                $snapshot = $reservation->cancellationPolicySnapshot;
-                $hoursUntilReservation = now()->diffInHours($reservationDateTime, false);
-
-                $refundAmount = $hoursUntilReservation >= $snapshot->cancellation_deadline_hours
-                    ? (float) $payment->amount
-                    : (float) $payment->amount * $snapshot->refund_percentage / 100;
-
-                $this->paymentService->refund($payment, $refundAmount);
-
-                return $refundAmount;
+            if (! $payment) {
+                return null;
             }
 
-            return null;
+            if ($payment->status === Payment::STATUS_PENDING) {
+                $this->paymentService->cancelPaymentIntent($payment);
+
+                return null;
+            }
+
+            if ($payment->status !== Payment::STATUS_SUCCEEDED) {
+                return null;
+            }
+
+            $snapshot = $reservation->cancellationPolicySnapshot;
+            $hoursUntilReservation = now()->diffInHours($reservationDateTime, false);
+
+            $refundAmount = $hoursUntilReservation >= $snapshot->cancellation_deadline_hours
+                ? (float) $payment->amount
+                : (float) $payment->amount * $snapshot->refund_percentage / 100;
+
+            $this->paymentService->refund($payment, $refundAmount);
+
+            return $refundAmount;
         });
 
         $reservation = $reservation->fresh();

--- a/tests/Unit/ReservationServiceTest.php
+++ b/tests/Unit/ReservationServiceTest.php
@@ -223,6 +223,42 @@ class ReservationServiceTest extends TestCase
         $this->assertEquals(Reservation::STATUS_CANCELLED, $result->status);
     }
 
+    public function test_cancel_pending_reservation_cancels_payment_intent(): void
+    {
+        /** @var Reservation&MockInterface $reservation */
+        $reservation = Mockery::mock(Reservation::class)->makePartial();
+        $reservation->status = Reservation::STATUS_PENDING;
+        $reservation->date = new \DateTime(now()->addDays(3)->format('Y-m-d'));
+        $reservation->start_time = '20:00:00';
+
+        /** @var Payment&MockInterface $payment */
+        $payment = Mockery::mock(Payment::class)->makePartial();
+        $payment->status = Payment::STATUS_PENDING;
+
+        $reservation->shouldReceive('getAttribute')->with('payment')->andReturn($payment);
+
+        $this->reservationRepository
+            ->shouldReceive('updateStatus')
+            ->with($reservation, Reservation::STATUS_CANCELLED)
+            ->once();
+
+        $this->paymentService
+            ->shouldReceive('cancelPaymentIntent')
+            ->with($payment)
+            ->once();
+
+        $this->paymentService->shouldNotReceive('refund');
+
+        /** @var Reservation&MockInterface $freshReservation */
+        $freshReservation = Mockery::mock(Reservation::class)->makePartial();
+        $freshReservation->status = Reservation::STATUS_CANCELLED;
+        $reservation->shouldReceive('fresh')->once()->andReturn($freshReservation);
+
+        $result = $this->service->cancel($reservation);
+
+        $this->assertEquals(Reservation::STATUS_CANCELLED, $result->status);
+    }
+
     public function test_cancel_rejects_non_cancellable_status(): void
     {
         /** @var Reservation&MockInterface $reservation */


### PR DESCRIPTION
## Summary

- Cancel the Stripe PaymentIntent when a `pending` reservation is cancelled, preventing the client from completing payment after cancellation
- Refactor `ReservationService::cancel()` payment handling to use guard clauses instead of nested conditionals
- Add unit test covering the pending payment cancellation scenario

## Test plan

- [x] New test: `test_cancel_pending_reservation_cancels_payment_intent` passes
- [x] Existing cancellation tests (full refund, partial refund, same day) still pass
- [x] Full test suite passes (223 tests, 0 failures)

Closes #91