### PR TITLE
Restrict PaymentIntent to card-only payment method

### DIFF
--- a/app/Services/PaymentService.php
+++ b/app/Services/PaymentService.php
@@ -21,6 +21,7 @@ class PaymentService
         $intent = PaymentIntent::create([
             'amount' => $amountInCents,
             'currency' => 'eur',
+            'payment_method_types' => ['card'],
             'metadata' => [
                 'reservation_id' => $reservationId,
             ],


### PR DESCRIPTION
## Summary

- Add `payment_method_types => ['card']` to `PaymentIntent::create()` to prevent Stripe from enabling redirect-based payment methods that require a `return_url`

## Test plan

- [x] Full test suite passes (223 tests, 0 failures)
- [x] PaymentIntent creation verified against Stripe test mode

Closes #95