### PR TITLE
Auto-cancel previous hold when creating a new reservation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ yarn-error.log
 /.vscode
 /.zed
 .mcp.json
+/.scribe/
+/public/vendor/scribe/
+/resources/views/scribe/

--- a/app/Repositories/ReservationRepository.php
+++ b/app/Repositories/ReservationRepository.php
@@ -39,12 +39,13 @@ class ReservationRepository
             ->exists();
     }
 
-    public function hasPendingReservation(int $userId): bool
+    public function findPendingReservation(int $userId): ?Reservation
     {
         return Reservation::pending()
             ->where('user_id', $userId)
             ->lockForUpdate()
-            ->exists();
+            ->with('payment')
+            ->first();
     }
 
     public function paginateForUser(int $userId, int $perPage = 6): LengthAwarePaginator

--- a/app/Services/ReservationService.php
+++ b/app/Services/ReservationService.php
@@ -23,7 +23,7 @@ use Illuminate\Validation\ValidationException;
 
 class ReservationService
 {
-    private const HOLD_DURATION_MINUTES = 15;
+    private const HOLD_DURATION_MINUTES = 10;
 
     public function __construct(
         private ReservationRepository $reservationRepository,
@@ -36,11 +36,14 @@ class ReservationService
     {
         $expiresAt = now()->addMinutes(self::HOLD_DURATION_MINUTES);
 
-        $result = DB::transaction(function () use ($dto, $expiresAt) {
-            if ($this->reservationRepository->hasPendingReservation($dto->user_id)) {
-                throw ValidationException::withMessages([
-                    'reservation' => ['Ya tienes una reserva pendiente de pago.'],
-                ]);
+        $previousPayment = null;
+
+        $result = DB::transaction(function () use ($dto, $expiresAt, &$previousPayment) {
+            $pendingReservation = $this->reservationRepository->findPendingReservation($dto->user_id);
+
+            if ($pendingReservation) {
+                $previousPayment = $pendingReservation->payment;
+                $this->releasePendingHold($pendingReservation);
             }
 
             $table = $this->tableRepository->findOrFail($dto->table_id);
@@ -84,7 +87,7 @@ class ReservationService
                 $dto->table_id, $dto->date, $dto->start_time, $endTime
             )) {
                 throw ValidationException::withMessages([
-                    'table_id' => ['Esta mesa no esta disponible para el horario seleccionado.'],
+                    'table_id' => ['Esta mesa esta siendo gestionada por otro usuario o ya fue reservada para el horario seleccionado.'],
                 ]);
             }
 
@@ -117,6 +120,10 @@ class ReservationService
                 'client_secret' => $paymentData['client_secret'],
             ];
         });
+
+        if ($previousPayment) {
+            $this->paymentService->cancelPaymentIntent($previousPayment);
+        }
 
         ExpireReservationJob::dispatch($result['reservation']->id)
             ->delay($expiresAt);
@@ -267,6 +274,15 @@ class ReservationService
         }
 
         return $this->tableRepository->findAvailable($dto->seats_requested, $dto->date, $dto->start_time, $endTime);
+    }
+
+    private function releasePendingHold(Reservation $pendingReservation): void
+    {
+        $status = $pendingReservation->expires_at->isPast()
+            ? Reservation::STATUS_EXPIRED
+            : Reservation::STATUS_CANCELLED;
+
+        $this->reservationRepository->updateStatus($pendingReservation, $status);
     }
 
     private function validateBusinessHours(string $startTime, string $endTime, RestaurantSetting $settings): void

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",
-        "knuckleswtf/scribe": "^5.7",
+        "knuckleswtf/scribe": "^5.9",
         "laravel-lang/common": "^6.7",
         "laravel/pail": "^1.1",
         "laravel/pint": "^1.13",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ef19558ca2dd73c78e1f8cf6f6dea0df",
+    "content-hash": "967e91d5cf81aaac4df8f54d990a2535",
     "packages": [
         {
             "name": "blade-ui-kit/blade-heroicons",
@@ -9185,16 +9185,16 @@
         },
         {
             "name": "knuckleswtf/scribe",
-            "version": "5.7.0",
+            "version": "5.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/knuckleswtf/scribe.git",
-                "reference": "81cadf88fca6b78a943af413c3818977c264b591"
+                "reference": "170cb6f8c56f1b26db692fdd1f26574b1765c6f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/knuckleswtf/scribe/zipball/81cadf88fca6b78a943af413c3818977c264b591",
-                "reference": "81cadf88fca6b78a943af413c3818977c264b591",
+                "url": "https://api.github.com/repos/knuckleswtf/scribe/zipball/170cb6f8c56f1b26db692fdd1f26574b1765c6f7",
+                "reference": "170cb6f8c56f1b26db692fdd1f26574b1765c6f7",
                 "shasum": ""
             },
             "require": {
@@ -9202,7 +9202,7 @@
                 "ext-json": "*",
                 "ext-pdo": "*",
                 "fakerphp/faker": "^1.23.1",
-                "laravel/framework": "^9.21 || ^10.0 || ^11.0 || ^12.0",
+                "laravel/framework": "^9.21 || ^10.0 || ^11.0 || ^12.0 || ^13.0",
                 "league/flysystem": "^3.0",
                 "mpociot/reflection-docblock": "^1.0.1",
                 "nikic/php-parser": "^5.0",
@@ -9211,8 +9211,8 @@
                 "php": ">=8.1",
                 "ramsey/uuid": "^4.2.2",
                 "shalvah/upgrader": "^0.6.0",
-                "symfony/var-exporter": "^6.0 || ^7.0",
-                "symfony/yaml": "^6.0 || ^7.0"
+                "symfony/var-exporter": "^6.0 || ^7.0 || ^8.0",
+                "symfony/yaml": "^6.0 || ^7.0 || ^8.0"
             },
             "replace": {
                 "mpociot/laravel-apidoc-generator": "*"
@@ -9223,13 +9223,13 @@
                 "laravel/pint": "^1.20",
                 "league/fractal": "^0.20",
                 "nikic/fast-route": "^1.3",
-                "orchestra/testbench": "^7.0 || ^8.0 || ^9.10 || ^10.0",
+                "orchestra/testbench": "^7.0 || ^8.0 || ^9.10 || ^10.0 || ^11.0",
                 "pestphp/pest": "^1.21 || ^2.0 || ^3.0 || ^4.0",
                 "phpstan/phpstan": "^2.1.5",
                 "phpunit/phpunit": "^9.0 || ^10.0 || ^11.0 || ^12.0",
                 "spatie/ray": "^1.41",
-                "symfony/css-selector": "^6.0 || ^7.0",
-                "symfony/dom-crawler": "^6.0 || ^7.0"
+                "symfony/css-selector": "^6.0 || ^7.0 || ^8.0",
+                "symfony/dom-crawler": "^6.0 || ^7.0 || ^8.0"
             },
             "type": "library",
             "extra": {
@@ -9266,7 +9266,7 @@
             ],
             "support": {
                 "issues": "https://github.com/knuckleswtf/scribe/issues",
-                "source": "https://github.com/knuckleswtf/scribe/tree/5.7.0"
+                "source": "https://github.com/knuckleswtf/scribe/tree/5.9.0"
             },
             "funding": [
                 {
@@ -9274,7 +9274,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2026-02-04T20:03:24+00:00"
+            "time": "2026-03-21T00:39:27+00:00"
         },
         {
             "name": "laravel-lang/actions",

--- a/tests/Feature/GuestReservationTest.php
+++ b/tests/Feature/GuestReservationTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Jobs\ExpireReservationJob;
 use App\Models\Payment;
+use App\Models\Reservation;
 use App\Models\Table;
 use App\Models\User;
 use App\Services\PaymentService;
@@ -145,21 +146,35 @@ class GuestReservationTest extends TestCase
             ->assertJsonValidationErrors(['name', 'email', 'phone', 'table_id', 'seats_requested', 'date', 'start_time']);
     }
 
-    public function test_guest_hold_rejects_if_lazy_user_has_pending_reservation(): void
+    public function test_guest_hold_cancels_previous_pending_and_creates_new(): void
     {
         Queue::fake();
 
         $this->paymentServiceMock
             ->shouldReceive('createPaymentIntent')
-            ->once()
-            ->andReturn([
-                'payment' => new Payment([
-                    'amount' => 10.00,
-                    'status' => Payment::STATUS_PENDING,
-                    'payment_gateway_id' => 'pi_test_first',
-                ]),
-                'client_secret' => 'pi_test_first_secret',
-            ]);
+            ->twice()
+            ->andReturn(
+                [
+                    'payment' => new Payment([
+                        'amount' => 10.00,
+                        'status' => Payment::STATUS_PENDING,
+                        'payment_gateway_id' => 'pi_test_first',
+                    ]),
+                    'client_secret' => 'pi_test_first_secret',
+                ],
+                [
+                    'payment' => new Payment([
+                        'amount' => 10.00,
+                        'status' => Payment::STATUS_PENDING,
+                        'payment_gateway_id' => 'pi_test_second',
+                    ]),
+                    'client_secret' => 'pi_test_second_secret',
+                ],
+            );
+
+        $this->paymentServiceMock
+            ->shouldReceive('cancelPaymentIntent')
+            ->once();
 
         $table = Table::factory()->create();
         $secondTable = Table::factory()->create();
@@ -168,12 +183,22 @@ class GuestReservationTest extends TestCase
             'table_id' => $table->id,
         ]));
 
+        $firstReservation = Reservation::first();
+
+        Payment::create([
+            'reservation_id' => $firstReservation->id,
+            'amount' => 10.00,
+            'status' => Payment::STATUS_PENDING,
+            'payment_gateway_id' => 'pi_test_first',
+        ]);
+
         $response = $this->postJson('/api/guest/reservations', $this->guestHoldData([
             'table_id' => $secondTable->id,
         ]));
 
-        $response->assertStatus(422)
-            ->assertJsonValidationErrors(['reservation']);
+        $response->assertStatus(201)
+            ->assertJsonPath('reservation.status', 'pending')
+            ->assertJsonPath('client_secret', 'pi_test_second_secret');
     }
 
     public function test_guest_hold_rejects_start_time_not_aligned_to_time_slot_interval(): void

--- a/tests/Feature/ReservationTest.php
+++ b/tests/Feature/ReservationTest.php
@@ -149,31 +149,54 @@ class ReservationTest extends TestCase
             ->assertJsonValidationErrors(['date']);
     }
 
-    public function test_hold_rejects_if_user_already_has_pending_reservation(): void
+    public function test_hold_cancels_previous_pending_and_creates_new(): void
     {
         Queue::fake();
 
         $this->paymentServiceMock
             ->shouldReceive('createPaymentIntent')
-            ->once()
-            ->andReturn([
-                'payment' => new Payment([
-                    'amount' => 10.00,
-                    'status' => Payment::STATUS_PENDING,
-                    'payment_gateway_id' => 'pi_test_first',
-                ]),
-                'client_secret' => 'pi_test_first_secret',
-            ]);
+            ->twice()
+            ->andReturn(
+                [
+                    'payment' => new Payment([
+                        'amount' => 10.00,
+                        'status' => Payment::STATUS_PENDING,
+                        'payment_gateway_id' => 'pi_test_first',
+                    ]),
+                    'client_secret' => 'pi_test_first_secret',
+                ],
+                [
+                    'payment' => new Payment([
+                        'amount' => 10.00,
+                        'status' => Payment::STATUS_PENDING,
+                        'payment_gateway_id' => 'pi_test_second',
+                    ]),
+                    'client_secret' => 'pi_test_second_secret',
+                ],
+            );
+
+        $this->paymentServiceMock
+            ->shouldReceive('cancelPaymentIntent')
+            ->once();
 
         $client = $this->clientUser();
-        $table = Table::factory()->create();
+        $firstTable = Table::factory()->create();
         $date = now()->addDays(3)->format('Y-m-d');
 
         $this->actingAs($client)->postJson('/api/reservations', [
-            'table_id' => $table->id,
+            'table_id' => $firstTable->id,
             'seats_requested' => 2,
             'date' => $date,
             'start_time' => '20:00',
+        ]);
+
+        $firstReservation = Reservation::where('user_id', $client->id)->first();
+
+        Payment::create([
+            'reservation_id' => $firstReservation->id,
+            'amount' => 10.00,
+            'status' => Payment::STATUS_PENDING,
+            'payment_gateway_id' => 'pi_test_first',
         ]);
 
         $secondTable = Table::factory()->create();
@@ -186,8 +209,90 @@ class ReservationTest extends TestCase
                 'start_time' => '20:00',
             ]);
 
-        $response->assertStatus(422)
-            ->assertJsonValidationErrors(['reservation']);
+        $response->assertStatus(201)
+            ->assertJsonPath('reservation.status', 'pending')
+            ->assertJsonPath('client_secret', 'pi_test_second_secret');
+
+        $this->assertDatabaseHas('reservations', [
+            'id' => $firstReservation->id,
+            'status' => Reservation::STATUS_CANCELLED,
+        ]);
+
+        $this->assertDatabaseHas('reservations', [
+            'table_id' => $secondTable->id,
+            'user_id' => $client->id,
+            'status' => Reservation::STATUS_PENDING,
+        ]);
+    }
+
+    public function test_hold_expires_previous_hold_when_already_past_expiration(): void
+    {
+        Queue::fake();
+
+        $this->paymentServiceMock
+            ->shouldReceive('createPaymentIntent')
+            ->twice()
+            ->andReturn(
+                [
+                    'payment' => new Payment([
+                        'amount' => 10.00,
+                        'status' => Payment::STATUS_PENDING,
+                        'payment_gateway_id' => 'pi_test_first',
+                    ]),
+                    'client_secret' => 'pi_test_first_secret',
+                ],
+                [
+                    'payment' => new Payment([
+                        'amount' => 10.00,
+                        'status' => Payment::STATUS_PENDING,
+                        'payment_gateway_id' => 'pi_test_second',
+                    ]),
+                    'client_secret' => 'pi_test_second_secret',
+                ],
+            );
+
+        $this->paymentServiceMock
+            ->shouldReceive('cancelPaymentIntent')
+            ->once();
+
+        $client = $this->clientUser();
+        $table = Table::factory()->create();
+        $date = now()->addDays(3)->format('Y-m-d');
+
+        $this->actingAs($client)->postJson('/api/reservations', [
+            'table_id' => $table->id,
+            'seats_requested' => 2,
+            'date' => $date,
+            'start_time' => '20:00',
+        ]);
+
+        $expiredReservation = Reservation::where('user_id', $client->id)->first();
+
+        Payment::create([
+            'reservation_id' => $expiredReservation->id,
+            'amount' => 10.00,
+            'status' => Payment::STATUS_PENDING,
+            'payment_gateway_id' => 'pi_test_first',
+        ]);
+
+        $expiredReservation->forceFill(['expires_at' => now()->subMinute()])->save();
+
+        $secondTable = Table::factory()->create();
+
+        $response = $this->actingAs($client)
+            ->postJson('/api/reservations', [
+                'table_id' => $secondTable->id,
+                'seats_requested' => 2,
+                'date' => $date,
+                'start_time' => '20:00',
+            ]);
+
+        $response->assertStatus(201);
+
+        $this->assertDatabaseHas('reservations', [
+            'id' => $expiredReservation->id,
+            'status' => Reservation::STATUS_EXPIRED,
+        ]);
     }
 
     public function test_hold_rejects_overlapping_reservation_on_same_table(): void


### PR DESCRIPTION
## Summary

- Auto-cancel previous pending hold when a user creates a new reservation, instead of blocking with a validation error
- Expire holds inline when `expires_at` has passed but the job hasn't executed yet (status `expired` vs `cancelled`)
- Move Stripe PaymentIntent cancellation outside the DB transaction to reduce lock duration
- Reduce hold duration from 15 to 10 minutes
- Improve overlapping reservation error message to distinguish between temporary holds and confirmed reservations

## Test plan

- [x] User with a pending hold can create a new reservation (previous hold cancelled, new one created with 201)
- [x] Expired-but-unprocessed hold is marked as `expired` inline, new reservation created
- [x] Previous hold's PaymentIntent is cancelled in Stripe after the transaction
- [x] Guest flow auto-cancels previous hold and creates new one
- [x] Full test suite passes (224 tests, 0 failures)

Closes #97