### PR TITLE
Add time slots endpoint and restrict interval/duration values

### DIFF
--- a/app/DTOs/TimeSlotsDTO.php
+++ b/app/DTOs/TimeSlotsDTO.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\DTOs;
+
+readonly class TimeSlotsDTO
+{
+    public function __construct(
+        public string $date,
+        public int $seats_requested,
+    ) {}
+}

--- a/app/Filament/Pages/ManageRestaurantSettings.php
+++ b/app/Filament/Pages/ManageRestaurantSettings.php
@@ -110,14 +110,15 @@ class ManageRestaurantSettings extends Page
 
                 Section::make('Reservas')
                     ->schema([
-                        TextInput::make('default_reservation_duration_minutes')
+                        Select::make('default_reservation_duration_minutes')
                             ->label('Duracion de reserva')
                             ->helperText('Tiempo que se bloquea la mesa por cada reserva.')
                             ->required()
-                            ->integer()
-                            ->minValue(15)
-                            ->maxValue(480)
-                            ->suffix('minutos'),
+                            ->options([
+                                30 => '30 minutos',
+                                60 => '60 minutos',
+                                90 => '90 minutos',
+                            ]),
 
                         TextInput::make('reminder_hours_before')
                             ->label('Recordatorio previo')
@@ -133,9 +134,7 @@ class ManageRestaurantSettings extends Page
                             ->helperText('Separacion entre horarios disponibles para reservar.')
                             ->required()
                             ->options([
-                                15 => '15 minutos',
                                 30 => '30 minutos',
-                                45 => '45 minutos',
                                 60 => '60 minutos',
                             ]),
                     ])

--- a/app/Http/Controllers/Client/ReservationController.php
+++ b/app/Http/Controllers/Client/ReservationController.php
@@ -4,9 +4,11 @@ namespace App\Http\Controllers\Client;
 
 use App\DTOs\AvailableTablesDTO;
 use App\DTOs\HoldReservationDTO;
+use App\DTOs\TimeSlotsDTO;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\AvailableTablesRequest;
 use App\Http\Requests\HoldReservationRequest;
+use App\Http\Requests\TimeSlotsRequest;
 use App\Http\Resources\ReservationResource;
 use App\Http\Resources\TableResource;
 use App\Models\Reservation;
@@ -17,6 +19,15 @@ use Illuminate\Http\Request;
 class ReservationController extends Controller
 {
     public function __construct(private ReservationService $service) {}
+
+    public function timeSlots(TimeSlotsRequest $request): JsonResponse
+    {
+        $dto = new TimeSlotsDTO(...$request->validated());
+
+        $slots = $this->service->getTimeSlots($dto);
+
+        return response()->json(['data' => $slots]);
+    }
 
     public function availableTables(AvailableTablesRequest $request): JsonResponse
     {

--- a/app/Http/Requests/TimeSlotsRequest.php
+++ b/app/Http/Requests/TimeSlotsRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class TimeSlotsRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'date' => ['required', 'date_format:Y-m-d'],
+            'seats_requested' => ['required', 'integer', 'min:1'],
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateRestaurantSettingRequest.php
+++ b/app/Http/Requests/UpdateRestaurantSettingRequest.php
@@ -18,9 +18,9 @@ class UpdateRestaurantSettingRequest extends FormRequest
             'deposit_per_person'                 => ['sometimes', 'numeric', 'min:0.01'],
             'cancellation_deadline_hours'         => ['sometimes', 'integer', 'min:1', 'max:168'],
             'refund_percentage'                   => ['sometimes', 'integer', 'min:0', 'max:100'],
-            'default_reservation_duration_minutes' => ['sometimes', 'integer', 'min:15', 'max:480'],
+            'default_reservation_duration_minutes' => ['sometimes', 'integer', Rule::in([30, 60, 90])],
             'reminder_hours_before'               => ['sometimes', 'integer', 'min:1', 'max:168'],
-            'time_slot_interval_minutes'          => ['sometimes', 'integer', Rule::in([15, 30, 45, 60])],
+            'time_slot_interval_minutes'          => ['sometimes', 'integer', Rule::in([30, 60])],
             'opening_time'                        => ['sometimes', 'date_format:H:i'],
             'closing_time'                        => ['sometimes', 'date_format:H:i'],
         ];

--- a/app/Http/Resources/PublicRestaurantSettingResource.php
+++ b/app/Http/Resources/PublicRestaurantSettingResource.php
@@ -10,9 +10,10 @@ class PublicRestaurantSettingResource extends JsonResource
     public function toArray(Request $request): array
     {
         return [
-            'opening_time'              => substr($this->opening_time, 0, 5),
-            'closing_time'              => substr($this->closing_time, 0, 5),
-            'time_slot_interval_minutes' => $this->time_slot_interval_minutes,
+            'opening_time'                         => substr($this->opening_time, 0, 5),
+            'closing_time'                         => substr($this->closing_time, 0, 5),
+            'time_slot_interval_minutes'            => $this->time_slot_interval_minutes,
+            'default_reservation_duration_minutes'  => $this->default_reservation_duration_minutes,
         ];
     }
 }

--- a/app/Models/Reservation.php
+++ b/app/Models/Reservation.php
@@ -82,6 +82,11 @@ class Reservation extends Model
         return $query->where('status', self::STATUS_PENDING);
     }
 
+    public function scopeConfirmed(Builder $query): Builder
+    {
+        return $query->where('status', self::STATUS_CONFIRMED);
+    }
+
     public function scopeExpired(Builder $query): Builder
     {
         return $query->where('status', self::STATUS_PENDING)

--- a/app/Models/Table.php
+++ b/app/Models/Table.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -21,6 +22,13 @@ class Table extends Model
     protected $casts = [
         'is_active' => 'boolean',
     ];
+
+    public function scopeMatchingCapacity(Builder $query, int $seatsRequested): Builder
+    {
+        return $query->where('is_active', true)
+            ->where('min_capacity', '<=', $seatsRequested)
+            ->where('max_capacity', '>=', $seatsRequested);
+    }
 
     public function reservations(): HasMany
     {

--- a/app/Repositories/TableRepository.php
+++ b/app/Repositories/TableRepository.php
@@ -41,11 +41,22 @@ class TableRepository
         $table->delete();
     }
 
+    public function countForCapacity(int $seatsRequested): int
+    {
+        return Table::matchingCapacity($seatsRequested)->count();
+    }
+
+    public function confirmedReservationsForCapacity(int $seatsRequested, string $date): \Illuminate\Support\Collection
+    {
+        return Reservation::confirmed()
+            ->where('date', $date)
+            ->whereIn('table_id', Table::matchingCapacity($seatsRequested)->select('id'))
+            ->get(['table_id', 'start_time', 'end_time']);
+    }
+
     public function findAvailable(int $seatsRequested, string $date, string $startTime, string $endTime): Collection
     {
-        return Table::where('is_active', true)
-            ->where('min_capacity', '<=', $seatsRequested)
-            ->where('max_capacity', '>=', $seatsRequested)
+        return Table::matchingCapacity($seatsRequested)
             ->whereNotIn('id', function ($query) use ($date, $startTime, $endTime) {
                 $query->select('table_id')
                     ->from('reservations')

--- a/app/Services/ReservationService.php
+++ b/app/Services/ReservationService.php
@@ -4,6 +4,7 @@ namespace App\Services;
 
 use App\DTOs\AvailableTablesDTO;
 use App\DTOs\HoldReservationDTO;
+use App\DTOs\TimeSlotsDTO;
 use App\Jobs\ExpireReservationJob;
 use App\Notifications\ReservationCancelledNotification;
 use App\Notifications\GuestReservationConfirmedNotification;
@@ -274,6 +275,72 @@ class ReservationService
         }
 
         return $this->tableRepository->findAvailable($dto->seats_requested, $dto->date, $dto->start_time, $endTime);
+    }
+
+    public function getTimeSlots(TimeSlotsDTO $dto): array
+    {
+        $date = Carbon::parse($dto->date);
+
+        if ($date->startOfDay()->lt(today()) || $date->greaterThan(now()->addWeek())) {
+            throw ValidationException::withMessages([
+                'date' => ['Las reservas deben ser dentro de los proximos 7 dias.'],
+            ]);
+        }
+
+        $settings = $this->settingRepository->get();
+
+        $totalTables = $this->tableRepository->countForCapacity($dto->seats_requested);
+
+        if ($totalTables === 0) {
+            return [];
+        }
+
+        $reservations = $this->tableRepository->confirmedReservationsForCapacity(
+            $dto->seats_requested,
+            $dto->date
+        );
+
+        $opening = Carbon::parse($settings->opening_time);
+        $closing = Carbon::parse($settings->closing_time);
+        $interval = $settings->time_slot_interval_minutes;
+        $duration = $settings->default_reservation_duration_minutes;
+
+        $isToday = Carbon::parse($dto->date)->isToday();
+        $now = now();
+
+        $slots = [];
+        $current = $opening->copy();
+
+        while ($current->lt($closing)) {
+            $slotStart = $current->format('H:i:s');
+            $slotEnd = $current->copy()->addMinutes($duration)->format('H:i:s');
+
+            if ($slotEnd > $closing->format('H:i:s')) {
+                $current->addMinutes($interval);
+                continue;
+            }
+
+            if ($isToday && Carbon::parse($dto->date . ' ' . $slotStart)->lte($now)) {
+                $status = 'blocked';
+            } else {
+                $bookedCount = $reservations
+                    ->filter(fn ($r) => $r->start_time < $slotEnd && $r->end_time > $slotStart)
+                    ->pluck('table_id')
+                    ->unique()
+                    ->count();
+
+                $status = $bookedCount >= $totalTables ? 'blocked' : 'available';
+            }
+
+            $slots[] = [
+                'start_time' => $current->format('H:i'),
+                'status' => $status,
+            ];
+
+            $current->addMinutes($interval);
+        }
+
+        return $slots;
     }
 
     private function releasePendingHold(Reservation $pendingReservation): void

--- a/database/seeders/RestaurantSettingSeeder.php
+++ b/database/seeders/RestaurantSettingSeeder.php
@@ -13,7 +13,7 @@ class RestaurantSettingSeeder extends Seeder
             'deposit_per_person' => 5.00,
             'cancellation_deadline_hours' => 24,
             'refund_percentage' => 50,
-            'default_reservation_duration_minutes' => 120,
+            'default_reservation_duration_minutes' => 60,
             'reminder_hours_before' => 24,
             'time_slot_interval_minutes' => 30,
             'opening_time' => '09:00',

--- a/routes/api.php
+++ b/routes/api.php
@@ -31,6 +31,7 @@ Route::prefix('auth')->group(function () {
 
 Route::get('settings/public', PublicSettingController::class);
 Route::get('menu-items', [ClientMenuItemController::class, 'index']);
+Route::get('reservations/time-slots', [ClientReservationController::class, 'timeSlots']);
 Route::get('reservations/available-tables', [ClientReservationController::class, 'availableTables']);
 Route::post('guest/reservations', [GuestReservationController::class, 'store']);
 

--- a/tests/Feature/ReservationTest.php
+++ b/tests/Feature/ReservationTest.php
@@ -329,7 +329,7 @@ class ReservationTest extends TestCase
                 'table_id' => $table->id,
                 'seats_requested' => 2,
                 'date' => $date,
-                'start_time' => '21:00',
+                'start_time' => '20:30',
             ]);
 
         $response->assertStatus(422)
@@ -535,7 +535,7 @@ class ReservationTest extends TestCase
                 'client_secret' => 'pi_test_slot_secret',
             ]);
 
-        RestaurantSetting::first()->update(['time_slot_interval_minutes' => 15]);
+        RestaurantSetting::first()->update(['time_slot_interval_minutes' => 30]);
 
         $table = Table::factory()->create();
 
@@ -544,7 +544,7 @@ class ReservationTest extends TestCase
                 'table_id' => $table->id,
                 'seats_requested' => 2,
                 'date' => now()->addDays(3)->format('Y-m-d'),
-                'start_time' => '20:15',
+                'start_time' => '20:30',
             ]);
 
         $response->assertStatus(201);
@@ -672,12 +672,12 @@ class ReservationTest extends TestCase
         RestaurantSetting::first()->update([
             'opening_time' => '09:00',
             'closing_time' => '22:00',
-            'default_reservation_duration_minutes' => 120,
+            'default_reservation_duration_minutes' => 60,
         ]);
 
         $response = $this->actingAs($this->clientUser())
             ->postJson('/api/reservations', $this->holdData([
-                'start_time' => '21:00',
+                'start_time' => '21:30',
             ]));
 
         $response->assertStatus(422)

--- a/tests/Feature/RestaurantSettingTest.php
+++ b/tests/Feature/RestaurantSettingTest.php
@@ -47,14 +47,14 @@ class RestaurantSettingTest extends TestCase
     {
         $response = $this->actingAs($this->adminUser())
             ->patchJson('/api/admin/settings', [
-                'time_slot_interval_minutes' => 15,
+                'time_slot_interval_minutes' => 30,
             ]);
 
         $response->assertStatus(200)
-            ->assertJsonPath('data.time_slot_interval_minutes', 15);
+            ->assertJsonPath('data.time_slot_interval_minutes', 30);
 
         $this->assertDatabaseHas('restaurant_settings', [
-            'time_slot_interval_minutes' => 15,
+            'time_slot_interval_minutes' => 30,
         ]);
     }
 
@@ -91,13 +91,30 @@ class RestaurantSettingTest extends TestCase
 
     public function test_update_rejects_invalid_time_slot_interval(): void
     {
-        $response = $this->actingAs($this->adminUser())
-            ->patchJson('/api/admin/settings', [
-                'time_slot_interval_minutes' => 20,
-            ]);
+        $admin = $this->adminUser();
 
-        $response->assertStatus(422)
-            ->assertJsonValidationErrors(['time_slot_interval_minutes']);
+        foreach ([15, 20, 45] as $invalidValue) {
+            $this->actingAs($admin)
+                ->patchJson('/api/admin/settings', [
+                    'time_slot_interval_minutes' => $invalidValue,
+                ])
+                ->assertStatus(422)
+                ->assertJsonValidationErrors(['time_slot_interval_minutes']);
+        }
+    }
+
+    public function test_update_rejects_invalid_reservation_duration(): void
+    {
+        $admin = $this->adminUser();
+
+        foreach ([15, 45, 120, 480] as $invalidValue) {
+            $this->actingAs($admin)
+                ->patchJson('/api/admin/settings', [
+                    'default_reservation_duration_minutes' => $invalidValue,
+                ])
+                ->assertStatus(422)
+                ->assertJsonValidationErrors(['default_reservation_duration_minutes']);
+        }
     }
 
     public function test_update_rejects_negative_deposit(): void
@@ -131,7 +148,7 @@ class RestaurantSettingTest extends TestCase
             ->assertStatus(403);
 
         $this->actingAs($this->clientUser())
-            ->patchJson('/api/admin/settings', ['time_slot_interval_minutes' => 15])
+            ->patchJson('/api/admin/settings', ['time_slot_interval_minutes' => 30])
             ->assertStatus(403);
     }
 
@@ -140,7 +157,7 @@ class RestaurantSettingTest extends TestCase
         $this->getJson('/api/admin/settings')
             ->assertStatus(401);
 
-        $this->patchJson('/api/admin/settings', ['time_slot_interval_minutes' => 15])
+        $this->patchJson('/api/admin/settings', ['time_slot_interval_minutes' => 30])
             ->assertStatus(401);
     }
 
@@ -219,11 +236,13 @@ class RestaurantSettingTest extends TestCase
                     'opening_time',
                     'closing_time',
                     'time_slot_interval_minutes',
+                    'default_reservation_duration_minutes',
                 ],
             ])
             ->assertJsonPath('data.opening_time', '09:00')
             ->assertJsonPath('data.closing_time', '23:00')
-            ->assertJsonPath('data.time_slot_interval_minutes', 30);
+            ->assertJsonPath('data.time_slot_interval_minutes', 30)
+            ->assertJsonPath('data.default_reservation_duration_minutes', 60);
     }
 
     public function test_public_endpoint_does_not_expose_sensitive_settings(): void

--- a/tests/Feature/TimeSlotsTest.php
+++ b/tests/Feature/TimeSlotsTest.php
@@ -1,0 +1,350 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Reservation;
+use App\Models\RestaurantSetting;
+use App\Models\Table;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TimeSlotsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed(\Database\Seeders\RoleSeeder::class);
+        $this->seed(\Database\Seeders\RestaurantSettingSeeder::class);
+    }
+
+    private function queryParams(array $overrides = []): array
+    {
+        return array_merge([
+            'date' => now()->addDays(3)->format('Y-m-d'),
+            'seats_requested' => 2,
+        ], $overrides);
+    }
+
+    // ── Slot generation ─────────────────────────────────────
+
+    public function test_returns_all_slots_between_opening_and_closing(): void
+    {
+        RestaurantSetting::first()->update([
+            'opening_time' => '09:00',
+            'closing_time' => '23:00',
+            'time_slot_interval_minutes' => 30,
+            'default_reservation_duration_minutes' => 60,
+        ]);
+
+        Table::factory()->create(['min_capacity' => 2, 'max_capacity' => 4]);
+
+        $response = $this->getJson('/api/reservations/time-slots?' . http_build_query($this->queryParams()));
+
+        // 09:00 to 22:00 stepping by 30 = 27 slots (22:30+60=23:30 > 23:00, excluded)
+        $response->assertStatus(200)
+            ->assertJsonCount(27, 'data')
+            ->assertJsonPath('data.0.start_time', '09:00')
+            ->assertJsonPath('data.0.status', 'available')
+            ->assertJsonPath('data.26.start_time', '22:00');
+    }
+
+    public function test_returns_slots_with_60_min_interval(): void
+    {
+        RestaurantSetting::first()->update([
+            'opening_time' => '10:00',
+            'closing_time' => '22:00',
+            'time_slot_interval_minutes' => 60,
+            'default_reservation_duration_minutes' => 60,
+        ]);
+
+        Table::factory()->create(['min_capacity' => 2, 'max_capacity' => 4]);
+
+        $response = $this->getJson('/api/reservations/time-slots?' . http_build_query($this->queryParams()));
+
+        // 10:00 to 21:00 stepping by 60 = 12 slots
+        $response->assertStatus(200)
+            ->assertJsonCount(12, 'data')
+            ->assertJsonPath('data.0.start_time', '10:00')
+            ->assertJsonPath('data.11.start_time', '21:00');
+    }
+
+    // ── Availability status ─────────────────────────────────
+
+    public function test_slot_blocked_when_all_tables_have_confirmed_reservations(): void
+    {
+        RestaurantSetting::first()->update([
+            'opening_time' => '18:00',
+            'closing_time' => '22:00',
+            'time_slot_interval_minutes' => 30,
+            'default_reservation_duration_minutes' => 60,
+        ]);
+
+        $date = now()->addDays(3)->format('Y-m-d');
+
+        $table1 = Table::factory()->create(['min_capacity' => 2, 'max_capacity' => 4]);
+        $table2 = Table::factory()->create(['min_capacity' => 2, 'max_capacity' => 4]);
+
+        Reservation::factory()->confirmed()->create([
+            'table_id' => $table1->id,
+            'date' => $date,
+            'start_time' => '19:00:00',
+            'end_time' => '20:00:00',
+        ]);
+
+        Reservation::factory()->confirmed()->create([
+            'table_id' => $table2->id,
+            'date' => $date,
+            'start_time' => '19:00:00',
+            'end_time' => '20:00:00',
+        ]);
+
+        $response = $this->getJson('/api/reservations/time-slots?' . http_build_query($this->queryParams([
+            'date' => $date,
+        ])));
+
+        $response->assertStatus(200);
+
+        $slots = collect($response->json('data'));
+
+        // 19:00 slot (19:00-20:00) overlaps both reservations (19:00-20:00) → blocked
+        $this->assertEquals('blocked', $slots->firstWhere('start_time', '19:00')['status']);
+
+        // 19:30 slot (19:30-20:30) overlaps both reservations (19:00-20:00) → blocked
+        $this->assertEquals('blocked', $slots->firstWhere('start_time', '19:30')['status']);
+
+        // 18:00 slot (18:00-19:00) does not overlap → available
+        $this->assertEquals('available', $slots->firstWhere('start_time', '18:00')['status']);
+
+        // 20:00 slot (20:00-21:00) does not overlap → available
+        $this->assertEquals('available', $slots->firstWhere('start_time', '20:00')['status']);
+    }
+
+    public function test_slot_available_when_at_least_one_table_free(): void
+    {
+        RestaurantSetting::first()->update([
+            'opening_time' => '18:00',
+            'closing_time' => '22:00',
+            'time_slot_interval_minutes' => 30,
+            'default_reservation_duration_minutes' => 60,
+        ]);
+
+        $date = now()->addDays(3)->format('Y-m-d');
+
+        $table1 = Table::factory()->create(['min_capacity' => 2, 'max_capacity' => 4]);
+        Table::factory()->create(['min_capacity' => 2, 'max_capacity' => 4]);
+
+        Reservation::factory()->confirmed()->create([
+            'table_id' => $table1->id,
+            'date' => $date,
+            'start_time' => '19:00:00',
+            'end_time' => '20:00:00',
+        ]);
+
+        $response = $this->getJson('/api/reservations/time-slots?' . http_build_query($this->queryParams([
+            'date' => $date,
+        ])));
+
+        $slots = collect($response->json('data'));
+
+        $this->assertEquals('available', $slots->firstWhere('start_time', '19:00')['status']);
+    }
+
+    public function test_pending_reservations_do_not_block_slots(): void
+    {
+        RestaurantSetting::first()->update([
+            'opening_time' => '18:00',
+            'closing_time' => '22:00',
+            'time_slot_interval_minutes' => 30,
+            'default_reservation_duration_minutes' => 60,
+        ]);
+
+        $date = now()->addDays(3)->format('Y-m-d');
+
+        $table = Table::factory()->create(['min_capacity' => 2, 'max_capacity' => 4]);
+
+        Reservation::factory()->pending()->create([
+            'table_id' => $table->id,
+            'date' => $date,
+            'start_time' => '19:00:00',
+            'end_time' => '20:00:00',
+        ]);
+
+        $response = $this->getJson('/api/reservations/time-slots?' . http_build_query($this->queryParams([
+            'date' => $date,
+        ])));
+
+        $slots = collect($response->json('data'));
+
+        $this->assertEquals('available', $slots->firstWhere('start_time', '19:00')['status']);
+    }
+
+    public function test_cancelled_and_expired_reservations_do_not_block_slots(): void
+    {
+        RestaurantSetting::first()->update([
+            'opening_time' => '18:00',
+            'closing_time' => '22:00',
+            'time_slot_interval_minutes' => 30,
+            'default_reservation_duration_minutes' => 60,
+        ]);
+
+        $date = now()->addDays(3)->format('Y-m-d');
+
+        $table = Table::factory()->create(['min_capacity' => 2, 'max_capacity' => 4]);
+
+        Reservation::factory()->cancelled()->create([
+            'table_id' => $table->id,
+            'date' => $date,
+            'start_time' => '19:00:00',
+            'end_time' => '20:00:00',
+        ]);
+
+        Reservation::factory()->expired()->create([
+            'table_id' => $table->id,
+            'date' => $date,
+            'start_time' => '19:00:00',
+            'end_time' => '20:00:00',
+        ]);
+
+        $response = $this->getJson('/api/reservations/time-slots?' . http_build_query($this->queryParams([
+            'date' => $date,
+        ])));
+
+        $slots = collect($response->json('data'));
+
+        $this->assertEquals('available', $slots->firstWhere('start_time', '19:00')['status']);
+    }
+
+    // ── Past slots ──────────────────────────────────────────
+
+    public function test_past_slots_today_are_blocked(): void
+    {
+        $this->travelTo(now()->setTime(15, 0));
+
+        RestaurantSetting::first()->update([
+            'opening_time' => '09:00',
+            'closing_time' => '23:00',
+            'time_slot_interval_minutes' => 30,
+            'default_reservation_duration_minutes' => 60,
+        ]);
+
+        Table::factory()->create(['min_capacity' => 2, 'max_capacity' => 4]);
+
+        $response = $this->getJson('/api/reservations/time-slots?' . http_build_query($this->queryParams([
+            'date' => now()->format('Y-m-d'),
+        ])));
+
+        $slots = collect($response->json('data'));
+
+        $this->assertEquals('blocked', $slots->firstWhere('start_time', '14:30')['status']);
+        $this->assertEquals('blocked', $slots->firstWhere('start_time', '15:00')['status']);
+        $this->assertEquals('available', $slots->firstWhere('start_time', '15:30')['status']);
+    }
+
+    // ── Edge cases ──────────────────────────────────────────
+
+    public function test_returns_empty_when_no_tables_match_capacity(): void
+    {
+        Table::factory()->create(['min_capacity' => 2, 'max_capacity' => 4]);
+
+        $response = $this->getJson('/api/reservations/time-slots?' . http_build_query($this->queryParams([
+            'seats_requested' => 20,
+        ])));
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data', []);
+    }
+
+    public function test_slot_with_90_min_duration_blocks_three_intervals(): void
+    {
+        RestaurantSetting::first()->update([
+            'opening_time' => '18:00',
+            'closing_time' => '22:00',
+            'time_slot_interval_minutes' => 30,
+            'default_reservation_duration_minutes' => 90,
+        ]);
+
+        $date = now()->addDays(3)->format('Y-m-d');
+
+        $table = Table::factory()->create(['min_capacity' => 2, 'max_capacity' => 4]);
+
+        // Reservation from 19:00 to 20:30 (90 min)
+        Reservation::factory()->confirmed()->create([
+            'table_id' => $table->id,
+            'date' => $date,
+            'start_time' => '19:00:00',
+            'end_time' => '20:30:00',
+        ]);
+
+        $response = $this->getJson('/api/reservations/time-slots?' . http_build_query($this->queryParams([
+            'date' => $date,
+        ])));
+
+        $slots = collect($response->json('data'));
+
+        // Slots that overlap with 19:00-20:30: 18:00(18:00-19:30), 18:30(18:30-20:00), 19:00(19:00-20:30), 19:30(19:30-21:00), 20:00(20:00-21:30)
+        $this->assertEquals('blocked', $slots->firstWhere('start_time', '18:00')['status']);
+        $this->assertEquals('blocked', $slots->firstWhere('start_time', '18:30')['status']);
+        $this->assertEquals('blocked', $slots->firstWhere('start_time', '19:00')['status']);
+        $this->assertEquals('blocked', $slots->firstWhere('start_time', '19:30')['status']);
+        $this->assertEquals('blocked', $slots->firstWhere('start_time', '20:00')['status']);
+
+        // 20:30 slot (20:30-22:00) does not overlap with 19:00-20:30 → available
+        $this->assertEquals('available', $slots->firstWhere('start_time', '20:30')['status']);
+    }
+
+    // ── Validation ──────────────────────────────────────────
+
+    public function test_rejects_missing_date(): void
+    {
+        $response = $this->getJson('/api/reservations/time-slots?' . http_build_query([
+            'seats_requested' => 2,
+        ]));
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['date']);
+    }
+
+    public function test_rejects_missing_seats_requested(): void
+    {
+        $response = $this->getJson('/api/reservations/time-slots?' . http_build_query([
+            'date' => now()->addDays(3)->format('Y-m-d'),
+        ]));
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['seats_requested']);
+    }
+
+    public function test_rejects_past_date(): void
+    {
+        $response = $this->getJson('/api/reservations/time-slots?' . http_build_query($this->queryParams([
+            'date' => now()->subDay()->format('Y-m-d'),
+        ])));
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['date']);
+    }
+
+    public function test_rejects_date_beyond_7_days(): void
+    {
+        $response = $this->getJson('/api/reservations/time-slots?' . http_build_query($this->queryParams([
+            'date' => now()->addDays(8)->format('Y-m-d'),
+        ])));
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['date']);
+    }
+
+    // ── Access ───────────────────────────────────────────────
+
+    public function test_endpoint_is_public(): void
+    {
+        Table::factory()->create(['min_capacity' => 2, 'max_capacity' => 4]);
+
+        $response = $this->getJson('/api/reservations/time-slots?' . http_build_query($this->queryParams()));
+
+        $response->assertStatus(200);
+    }
+}


### PR DESCRIPTION
## Summary
- Restrict `time_slot_interval_minutes` to [30, 60] and `default_reservation_duration_minutes` to [30, 60, 90]
- Add `GET /api/reservations/time-slots?date=...&seats_requested=...` public endpoint that returns all slots for a given date with `available`/`blocked` status based on confirmed reservations only (optimistic availability)
- Expose `default_reservation_duration_minutes` in public settings endpoint
- Extract `matchingCapacity` scope on Table model to eliminate duplicated capacity filter across repository methods

Closes #99

## Test plan
- [ ] `php artisan test --filter=TimeSlotsTest` (14 tests: slot generation, availability status, optimistic availability, past slots, validation, public access)
- [ ] `php artisan test --filter=RestaurantSettingTest` (17 tests: updated interval/duration validation, public endpoint includes duration)
- [ ] `php artisan test --filter=ReservationTest` (28 tests: adjusted overlap and closing-time tests for new duration default)
- [ ] `php artisan test --filter=AvailableTablesTest` (12 tests: regression check with matchingCapacity scope)
- [ ] `php artisan test` (239 tests, 0 failures)