### PR TITLE
Add email confirmation and Spanish phone validation

### DIFF
--- a/app/DTOs/RegisterDTO.php
+++ b/app/DTOs/RegisterDTO.php
@@ -7,6 +7,7 @@ readonly class RegisterDTO
     public function __construct(
         public string $name,
         public string $email,
+        public string $phone,
         public string $password,
     ) {}
 }

--- a/app/Http/Requests/RegisterRequest.php
+++ b/app/Http/Requests/RegisterRequest.php
@@ -16,7 +16,8 @@ class RegisterRequest extends FormRequest
     {
         return [
             'name'     => ['required', 'string', 'max:255'],
-            'email'    => ['required', 'string', 'email', 'max:255', 'unique:users'],
+            'email'    => ['required', 'string', 'email', 'max:255', 'unique:users', 'confirmed'],
+            'phone'    => ['required', 'string', 'regex:/^[6-9]\d{8}$/'],
             'password' => ['required', 'string', Password::min(8)->mixedCase()->numbers(), 'confirmed'],
         ];
     }

--- a/app/Http/Requests/UpdateProfileRequest.php
+++ b/app/Http/Requests/UpdateProfileRequest.php
@@ -17,7 +17,7 @@ class UpdateProfileRequest extends FormRequest
         return [
             'name'  => ['sometimes', 'string', 'max:255'],
             'email' => ['sometimes', 'string', 'email', 'max:255', Rule::unique('users')->ignore($this->user()->id)],
-            'phone' => ['sometimes', 'nullable', 'string', 'max:20'],
+            'phone' => ['sometimes', 'nullable', 'string', 'regex:/^[6-9]\d{8}$/'],
         ];
     }
 }

--- a/app/Services/AuthService.php
+++ b/app/Services/AuthService.php
@@ -33,7 +33,7 @@ class AuthService
             ]);
 
             $user->assignRole('client');
-            $user->clientProfile()->create([]);
+            $user->clientProfile()->create(['phone' => $dto->phone]);
 
             return $user;
         });

--- a/tests/Feature/AuthTest.php
+++ b/tests/Feature/AuthTest.php
@@ -23,6 +23,8 @@ class AuthTest extends TestCase
         $response = $this->postJson('/api/auth/register', [
             'name'                  => 'Test User',
             'email'                 => 'test@example.com',
+            'email_confirmation'    => 'test@example.com',
+            'phone'                 => '612345678',
             'password'              => 'Password1',
             'password_confirmation' => 'Password1',
         ]);
@@ -41,6 +43,8 @@ class AuthTest extends TestCase
         $this->postJson('/api/auth/register', [
             'name'                  => 'Test User',
             'email'                 => 'test@example.com',
+            'email_confirmation'    => 'test@example.com',
+            'phone'                 => '612345678',
             'password'              => 'Password1',
             'password_confirmation' => 'Password1',
         ]);
@@ -55,6 +59,8 @@ class AuthTest extends TestCase
         $this->postJson('/api/auth/register', [
             'name'                  => 'Test User',
             'email'                 => 'test@example.com',
+            'email_confirmation'    => 'test@example.com',
+            'phone'                 => '612345678',
             'password'              => 'Password1',
             'password_confirmation' => 'Password1',
         ]);
@@ -62,6 +68,7 @@ class AuthTest extends TestCase
         $user = User::where('email', 'test@example.com')->first();
 
         $this->assertNotNull($user->clientProfile);
+        $this->assertEquals('612345678', $user->clientProfile->phone);
     }
 
     public function test_register_requires_unique_email(): void
@@ -69,6 +76,8 @@ class AuthTest extends TestCase
         $data = [
             'name'                  => 'Test User',
             'email'                 => 'test@example.com',
+            'email_confirmation'    => 'test@example.com',
+            'phone'                 => '612345678',
             'password'              => 'Password1',
             'password_confirmation' => 'Password1',
         ];
@@ -85,6 +94,8 @@ class AuthTest extends TestCase
         $response = $this->postJson('/api/auth/register', [
             'name'                  => 'Test User',
             'email'                 => 'test@example.com',
+            'email_confirmation'    => 'test@example.com',
+            'phone'                 => '612345678',
             'password'              => '12345678',
             'password_confirmation' => '12345678',
         ]);
@@ -96,13 +107,73 @@ class AuthTest extends TestCase
     public function test_register_requires_password_confirmation(): void
     {
         $response = $this->postJson('/api/auth/register', [
-            'name'     => 'Test User',
-            'email'    => 'test@example.com',
-            'password' => 'Password1',
+            'name'                  => 'Test User',
+            'email'                 => 'test@example.com',
+            'email_confirmation'    => 'test@example.com',
+            'phone'                 => '612345678',
+            'password'              => 'Password1',
         ]);
 
         $response->assertStatus(422)
             ->assertJsonValidationErrors(['password']);
+    }
+
+    public function test_register_requires_email_confirmation(): void
+    {
+        $response = $this->postJson('/api/auth/register', [
+            'name'                  => 'Test User',
+            'email'                 => 'test@example.com',
+            'phone'                 => '612345678',
+            'password'              => 'Password1',
+            'password_confirmation' => 'Password1',
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['email']);
+    }
+
+    public function test_register_rejects_mismatched_email_confirmation(): void
+    {
+        $response = $this->postJson('/api/auth/register', [
+            'name'                  => 'Test User',
+            'email'                 => 'test@example.com',
+            'email_confirmation'    => 'typo@example.com',
+            'phone'                 => '612345678',
+            'password'              => 'Password1',
+            'password_confirmation' => 'Password1',
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['email']);
+    }
+
+    public function test_register_requires_phone(): void
+    {
+        $response = $this->postJson('/api/auth/register', [
+            'name'                  => 'Test User',
+            'email'                 => 'test@example.com',
+            'email_confirmation'    => 'test@example.com',
+            'password'              => 'Password1',
+            'password_confirmation' => 'Password1',
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['phone']);
+    }
+
+    public function test_register_rejects_invalid_phone_format(): void
+    {
+        $response = $this->postJson('/api/auth/register', [
+            'name'                  => 'Test User',
+            'email'                 => 'test@example.com',
+            'email_confirmation'    => 'test@example.com',
+            'phone'                 => '12345',
+            'password'              => 'Password1',
+            'password_confirmation' => 'Password1',
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['phone']);
     }
 
     public function test_user_can_login(): void

--- a/tests/Feature/ProfileTest.php
+++ b/tests/Feature/ProfileTest.php
@@ -129,6 +129,39 @@ class ProfileTest extends TestCase
             ->assertJsonPath('data.phone', '699999999');
     }
 
+    public function test_update_rejects_invalid_phone_format(): void
+    {
+        $user = $this->clientWithProfile();
+
+        $response = $this->actingAs($user)
+            ->putJson('/api/profile', ['phone' => '12345']);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['phone']);
+    }
+
+    public function test_update_accepts_valid_spanish_phone(): void
+    {
+        $user = $this->clientWithProfile();
+
+        $response = $this->actingAs($user)
+            ->putJson('/api/profile', ['phone' => '712345678']);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.phone', '712345678');
+    }
+
+    public function test_update_allows_null_phone(): void
+    {
+        $user = $this->clientWithProfile();
+
+        $response = $this->actingAs($user)
+            ->putJson('/api/profile', ['phone' => null]);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.phone', null);
+    }
+
     public function test_update_rejects_duplicate_email(): void
     {
         User::factory()->create(['email' => 'taken@example.com']);


### PR DESCRIPTION
## Summary

- Require `email_confirmation` field on registration to prevent typos in email address
- Require `phone` field on registration with Spanish format validation (9 digits, starting with 6-9)
- Validate phone format on profile update with same Spanish format rule
- Save phone to `client_profiles` during registration

## Test plan

- [x] Registration succeeds with valid email confirmation and phone
- [x] Registration fails without email confirmation
- [x] Registration fails with mismatched email confirmation
- [x] Registration fails without phone
- [x] Registration fails with invalid phone format
- [x] Phone is saved to client_profiles on registration
- [x] Profile update rejects invalid phone format
- [x] Profile update accepts valid Spanish phone
- [x] Profile update allows null phone
- [x] All 246 existing tests pass (no regressions)

Closes #101