### PR TITLE
fix: wrap hold reservation responses in data key

### DIFF
--- a/api.json
+++ b/api.json
@@ -515,14 +515,22 @@
                                 "schema": {
                                     "type": "object",
                                     "properties": {
-                                        "reservation": {
-                                            "$ref": "#/components/schemas/ReservationResource"
-                                        },
-                                        "client_secret": {}
+                                        "data": {
+                                            "type": "object",
+                                            "properties": {
+                                                "reservation": {
+                                                    "$ref": "#/components/schemas/ReservationResource"
+                                                },
+                                                "client_secret": {}
+                                            },
+                                            "required": [
+                                                "reservation",
+                                                "client_secret"
+                                            ]
+                                        }
                                     },
                                     "required": [
-                                        "reservation",
-                                        "client_secret"
+                                        "data"
                                     ]
                                 }
                             }
@@ -546,6 +554,13 @@
                         "in": "query",
                         "schema": {
                             "$ref": "#/components/schemas/MenuCategory"
+                        }
+                    },
+                    {
+                        "name": "featured",
+                        "in": "query",
+                        "schema": {
+                            "type": "boolean"
                         }
                     }
                 ],
@@ -589,6 +604,13 @@
                         "in": "query",
                         "schema": {
                             "$ref": "#/components/schemas/MenuCategory"
+                        }
+                    },
+                    {
+                        "name": "featured",
+                        "in": "query",
+                        "schema": {
+                            "type": "boolean"
                         }
                     }
                 ],
@@ -945,6 +967,221 @@
                 }
             }
         },
+        "/profile": {
+            "get": {
+                "operationId": "profile.show",
+                "tags": [
+                    "Profile"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "`UserResource`",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/components/schemas/UserResource"
+                                        }
+                                    },
+                                    "required": [
+                                        "data"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/AuthenticationException"
+                    }
+                }
+            },
+            "put": {
+                "operationId": "profile.update",
+                "tags": [
+                    "Profile"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UpdateProfileRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "`UserResource`",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/components/schemas/UserResource"
+                                        }
+                                    },
+                                    "required": [
+                                        "data"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/AuthenticationException"
+                    },
+                    "422": {
+                        "$ref": "#/components/responses/ValidationException"
+                    }
+                }
+            }
+        },
+        "/profile/password": {
+            "put": {
+                "operationId": "profile.updatePassword",
+                "tags": [
+                    "Profile"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UpdatePasswordRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "const": "Contrasena actualizada correctamente."
+                                        }
+                                    },
+                                    "required": [
+                                        "message"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/AuthenticationException"
+                    },
+                    "422": {
+                        "$ref": "#/components/responses/ValidationException"
+                    }
+                }
+            }
+        },
+        "/settings/public": {
+            "get": {
+                "operationId": "publicSetting",
+                "tags": [
+                    "PublicSetting"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "`PublicRestaurantSettingResource`",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/components/schemas/PublicRestaurantSettingResource"
+                                        }
+                                    },
+                                    "required": [
+                                        "data"
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/reservations/time-slots": {
+            "get": {
+                "operationId": "reservation.timeSlots",
+                "tags": [
+                    "Reservation"
+                ],
+                "parameters": [
+                    {
+                        "name": "date",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "date"
+                        }
+                    },
+                    {
+                        "name": "seats_requested",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "minimum": 1
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "start_time": {
+                                                        "type": "string"
+                                                    },
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "blocked",
+                                                            "available"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "start_time",
+                                                    "status"
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "required": [
+                                        "data"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "$ref": "#/components/responses/ValidationException"
+                    }
+                }
+            }
+        },
         "/reservations/available-tables": {
             "get": {
                 "operationId": "reservation.availableTables",
@@ -1110,14 +1347,22 @@
                                 "schema": {
                                     "type": "object",
                                     "properties": {
-                                        "reservation": {
-                                            "$ref": "#/components/schemas/ReservationResource"
-                                        },
-                                        "client_secret": {}
+                                        "data": {
+                                            "type": "object",
+                                            "properties": {
+                                                "reservation": {
+                                                    "$ref": "#/components/schemas/ReservationResource"
+                                                },
+                                                "client_secret": {}
+                                            },
+                                            "required": [
+                                                "reservation",
+                                                "client_secret"
+                                            ]
+                                        }
                                     },
                                     "required": [
-                                        "reservation",
-                                        "client_secret"
+                                        "data"
                                     ]
                                 }
                             }
@@ -1777,6 +2022,9 @@
                     "is_available": {
                         "type": "boolean"
                     },
+                    "is_featured": {
+                        "type": "boolean"
+                    },
                     "daily_stock": {
                         "type": [
                             "integer",
@@ -1794,9 +2042,34 @@
                     "price",
                     "category",
                     "is_available",
+                    "is_featured",
                     "created_at"
                 ],
                 "title": "MenuItemResource"
+            },
+            "PublicRestaurantSettingResource": {
+                "type": "object",
+                "properties": {
+                    "opening_time": {
+                        "type": "string"
+                    },
+                    "closing_time": {
+                        "type": "string"
+                    },
+                    "time_slot_interval_minutes": {
+                        "type": "string"
+                    },
+                    "default_reservation_duration_minutes": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "opening_time",
+                    "closing_time",
+                    "time_slot_interval_minutes",
+                    "default_reservation_duration_minutes"
+                ],
+                "title": "PublicRestaurantSettingResource"
             },
             "RegisterRequest": {
                 "type": "object",
@@ -1810,8 +2083,17 @@
                         "format": "email",
                         "maxLength": 255
                     },
+                    "phone": {
+                        "type": "string",
+                        "pattern": "^[6-9]\\d{8}$"
+                    },
                     "password": {
                         "type": "string"
+                    },
+                    "email_confirmation": {
+                        "type": "string",
+                        "format": "email",
+                        "maxLength": 255
                     },
                     "password_confirmation": {
                         "type": "string"
@@ -1820,7 +2102,9 @@
                 "required": [
                     "name",
                     "email",
+                    "phone",
                     "password",
+                    "email_confirmation",
                     "password_confirmation"
                 ],
                 "title": "RegisterRequest"
@@ -1983,6 +2267,12 @@
                     },
                     "time_slot_interval_minutes": {
                         "type": "integer"
+                    },
+                    "opening_time": {
+                        "type": "string"
+                    },
+                    "closing_time": {
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -1991,7 +2281,9 @@
                     "refund_percentage",
                     "default_reservation_duration_minutes",
                     "reminder_hours_before",
-                    "time_slot_interval_minutes"
+                    "time_slot_interval_minutes",
+                    "opening_time",
+                    "closing_time"
                 ],
                 "title": "RestaurantSettingResource"
             },
@@ -2128,6 +2420,48 @@
                 },
                 "title": "UpdateMenuItemRequest"
             },
+            "UpdatePasswordRequest": {
+                "type": "object",
+                "properties": {
+                    "current_password": {
+                        "type": "string"
+                    },
+                    "password": {
+                        "type": "string"
+                    },
+                    "password_confirmation": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "current_password",
+                    "password",
+                    "password_confirmation"
+                ],
+                "title": "UpdatePasswordRequest"
+            },
+            "UpdateProfileRequest": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 255
+                    },
+                    "email": {
+                        "type": "string",
+                        "format": "email",
+                        "maxLength": 255
+                    },
+                    "phone": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "pattern": "^[6-9]\\d{8}$"
+                    }
+                },
+                "title": "UpdateProfileRequest"
+            },
             "UpdateRestaurantSettingRequest": {
                 "type": "object",
                 "properties": {
@@ -2147,8 +2481,11 @@
                     },
                     "default_reservation_duration_minutes": {
                         "type": "integer",
-                        "minimum": 15,
-                        "maximum": 480
+                        "enum": [
+                            "30",
+                            "60",
+                            "90"
+                        ]
                     },
                     "reminder_hours_before": {
                         "type": "integer",
@@ -2158,11 +2495,15 @@
                     "time_slot_interval_minutes": {
                         "type": "integer",
                         "enum": [
-                            "15",
                             "30",
-                            "45",
                             "60"
                         ]
+                    },
+                    "opening_time": {
+                        "type": "string"
+                    },
+                    "closing_time": {
+                        "type": "string"
                     }
                 },
                 "title": "UpdateRestaurantSettingRequest"
@@ -2210,13 +2551,21 @@
                     "email": {
                         "type": "string"
                     },
-                    "role": {}
+                    "phone": {
+                        "type": "string"
+                    },
+                    "role": {},
+                    "is_guest": {
+                        "type": "boolean"
+                    }
                 },
                 "required": [
                     "id",
                     "name",
                     "email",
-                    "role"
+                    "phone",
+                    "role",
+                    "is_guest"
                 ],
                 "title": "UserResource"
             }

--- a/app/Http/Controllers/Client/GuestReservationController.php
+++ b/app/Http/Controllers/Client/GuestReservationController.php
@@ -22,8 +22,10 @@ class GuestReservationController extends Controller
         $result = $this->guestReservationService->hold($dto);
 
         return response()->json([
-            'reservation' => new ReservationResource($result['reservation']->load('table', 'payment')),
-            'client_secret' => $result['client_secret'],
+            'data' => [
+                'reservation' => new ReservationResource($result['reservation']->load('table', 'payment')),
+                'client_secret' => $result['client_secret'],
+            ],
         ], 201);
     }
 }

--- a/app/Http/Controllers/Client/ReservationController.php
+++ b/app/Http/Controllers/Client/ReservationController.php
@@ -53,8 +53,10 @@ class ReservationController extends Controller
         $result = $this->service->hold($dto);
 
         return response()->json([
-            'reservation' => new ReservationResource($result['reservation']->load('table', 'payment')),
-            'client_secret' => $result['client_secret'],
+            'data' => [
+                'reservation' => new ReservationResource($result['reservation']->load('table', 'payment')),
+                'client_secret' => $result['client_secret'],
+            ],
         ], 201);
     }
 

--- a/tests/Feature/GuestReservationTest.php
+++ b/tests/Feature/GuestReservationTest.php
@@ -72,10 +72,12 @@ class GuestReservationTest extends TestCase
 
         $response->assertStatus(201)
             ->assertJsonStructure([
-                'reservation' => ['id', 'table', 'seats_requested', 'date', 'start_time', 'status', 'expires_at'],
-                'client_secret',
+                'data' => [
+                    'reservation' => ['id', 'table', 'seats_requested', 'date', 'start_time', 'status', 'expires_at'],
+                    'client_secret',
+                ],
             ])
-            ->assertJsonPath('reservation.status', 'pending');
+            ->assertJsonPath('data.reservation.status', 'pending');
 
         $this->assertDatabaseHas('users', [
             'email' => 'juan@example.com',
@@ -197,8 +199,8 @@ class GuestReservationTest extends TestCase
         ]));
 
         $response->assertStatus(201)
-            ->assertJsonPath('reservation.status', 'pending')
-            ->assertJsonPath('client_secret', 'pi_test_second_secret');
+            ->assertJsonPath('data.reservation.status', 'pending')
+            ->assertJsonPath('data.client_secret', 'pi_test_second_secret');
     }
 
     public function test_guest_hold_rejects_start_time_not_aligned_to_time_slot_interval(): void

--- a/tests/Feature/ReservationTest.php
+++ b/tests/Feature/ReservationTest.php
@@ -73,11 +73,13 @@ class ReservationTest extends TestCase
 
         $response->assertStatus(201)
             ->assertJsonStructure([
-                'reservation' => ['id', 'table', 'seats_requested', 'date', 'start_time', 'status', 'expires_at'],
-                'client_secret',
+                'data' => [
+                    'reservation' => ['id', 'table', 'seats_requested', 'date', 'start_time', 'status', 'expires_at'],
+                    'client_secret',
+                ],
             ])
-            ->assertJsonPath('reservation.status', 'pending')
-            ->assertJsonPath('client_secret', 'pi_test_123_secret');
+            ->assertJsonPath('data.reservation.status', 'pending')
+            ->assertJsonPath('data.client_secret', 'pi_test_123_secret');
 
         $this->assertDatabaseHas('reservations', [
             'table_id' => $table->id,
@@ -210,8 +212,8 @@ class ReservationTest extends TestCase
             ]);
 
         $response->assertStatus(201)
-            ->assertJsonPath('reservation.status', 'pending')
-            ->assertJsonPath('client_secret', 'pi_test_second_secret');
+            ->assertJsonPath('data.reservation.status', 'pending')
+            ->assertJsonPath('data.client_secret', 'pi_test_second_secret');
 
         $this->assertDatabaseHas('reservations', [
             'id' => $firstReservation->id,


### PR DESCRIPTION
## Summary
- Wrap POST /reservations and POST /guest/reservations payloads in a `data` key, matching the rest of the API contract
- Regenerate OpenAPI spec (api.json) via `scramble:export` so the documented response schemas match the code
- Update hold-reservation feature tests to assert the new response shape

Closes #104

## Test plan
- [x] `php artisan test` (246 passed)
- [ ] Verify Stripe payment flow on the frontend: hold → read `response.data.client_secret` → mount Stripe Elements