### PR TITLE
Validate opening/closing times are aligned to time_slot_interval_minutes

### DIFF
--- a/app/Http/Requests/UpdateRestaurantSettingRequest.php
+++ b/app/Http/Requests/UpdateRestaurantSettingRequest.php
@@ -33,15 +33,29 @@ class UpdateRestaurantSettingRequest extends FormRequest
                 $settings = $this->existingSettings();
                 $opening = $this->input('opening_time', $settings->opening_time);
                 $closing = $this->input('closing_time', $settings->closing_time);
+                $interval = (int) $this->input('time_slot_interval_minutes', $settings->time_slot_interval_minutes);
 
-                $openingMinutes = (int) substr($opening, 0, 2) * 60 + (int) substr($opening, 3, 2);
-                $closingMinutes = (int) substr($closing, 0, 2) * 60 + (int) substr($closing, 3, 2);
+                $openingMinutes = $this->toMinutes($opening);
+                $closingMinutes = $this->toMinutes($closing);
 
                 if ($openingMinutes >= $closingMinutes) {
                     $validator->errors()->add('opening_time', 'La hora de apertura debe ser anterior a la hora de cierre.');
                 }
+
+                if ($openingMinutes % $interval !== 0) {
+                    $validator->errors()->add('opening_time', "La hora de apertura debe estar alineada a intervalos de {$interval} minutos.");
+                }
+
+                if ($closingMinutes % $interval !== 0) {
+                    $validator->errors()->add('closing_time', "La hora de cierre debe estar alineada a intervalos de {$interval} minutos.");
+                }
             },
         ];
+    }
+
+    private function toMinutes(string $time): int
+    {
+        return (int) substr($time, 0, 2) * 60 + (int) substr($time, 3, 2);
     }
 
     private function existingSettings(): \App\Models\RestaurantSetting

--- a/tests/Feature/RestaurantSettingTest.php
+++ b/tests/Feature/RestaurantSettingTest.php
@@ -224,6 +224,56 @@ class RestaurantSettingTest extends TestCase
             ->assertJsonValidationErrors(['opening_time']);
     }
 
+    public function test_update_rejects_opening_time_not_aligned_to_interval(): void
+    {
+        RestaurantSetting::first()->update(['time_slot_interval_minutes' => 60]);
+
+        $this->actingAs($this->adminUser())
+            ->patchJson('/api/admin/settings', [
+                'opening_time' => '08:30',
+            ])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['opening_time']);
+    }
+
+    public function test_update_rejects_closing_time_not_aligned_to_interval(): void
+    {
+        RestaurantSetting::first()->update(['time_slot_interval_minutes' => 60]);
+
+        $this->actingAs($this->adminUser())
+            ->patchJson('/api/admin/settings', [
+                'closing_time' => '22:30',
+            ])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['closing_time']);
+    }
+
+    public function test_update_rejects_interval_change_that_misaligns_existing_times(): void
+    {
+        RestaurantSetting::first()->update(['opening_time' => '08:30']);
+
+        $this->actingAs($this->adminUser())
+            ->patchJson('/api/admin/settings', [
+                'time_slot_interval_minutes' => 60,
+            ])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['opening_time']);
+    }
+
+    public function test_update_accepts_aligned_times_with_60_minute_interval(): void
+    {
+        RestaurantSetting::first()->update(['time_slot_interval_minutes' => 60]);
+
+        $this->actingAs($this->adminUser())
+            ->patchJson('/api/admin/settings', [
+                'opening_time' => '08:00',
+                'closing_time' => '22:00',
+            ])
+            ->assertStatus(200)
+            ->assertJsonPath('data.opening_time', '08:00')
+            ->assertJsonPath('data.closing_time', '22:00');
+    }
+
     // ── Public Endpoint ─────────────────────────────────────
 
     public function test_public_endpoint_returns_schedule_settings(): void


### PR DESCRIPTION
## Summary

- Added cross-field validation to reject `opening_time` or `closing_time` that are not multiples of `time_slot_interval_minutes`
- Validation also applies when updating the interval itself — rejects changes that would misalign existing times
- Extracted `toMinutes()` helper to remove duplicated `substr`-based parsing in the `after()` callback

## Test plan

- [x] `opening_time = 08:30` with interval 60 → 422
- [x] `closing_time = 22:30` with interval 60 → 422
- [x] Updating `time_slot_interval_minutes` to 60 when existing `opening_time` is `08:30` → 422
- [x] Aligned times with 60-minute interval → 200
- [x] All existing `RestaurantSettingTest` cases remain green
- [x] Full test suite: 256 tests passing

Closes #109