### PR TITLE
Fix confirmPayment to refund any non-pending reservation on late payment

### DIFF
--- a/app/Notifications/ReservationPaymentRefundedNotification.php
+++ b/app/Notifications/ReservationPaymentRefundedNotification.php
@@ -8,15 +8,14 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
-class ReservationExpiredRefundNotification extends Notification implements ShouldQueue
+class ReservationPaymentRefundedNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 
     public function __construct(
         private Reservation $reservation,
         private float $refundAmount,
-    ) {
-    }
+    ) {}
 
     public function via(object $notifiable): array
     {
@@ -27,18 +26,17 @@ class ReservationExpiredRefundNotification extends Notification implements Shoul
     {
         $this->reservation->loadMissing('table');
         $reservation = $this->reservation;
-        /** @var \App\Models\Table $table */
         $table = $reservation->table;
         $formatted = number_format($this->refundAmount, 2, ',', '.');
 
         return (new MailMessage())
-            ->subject('Pago reembolsado - Reserva expirada')
+            ->subject('Reembolso procesado por tu reserva')
             ->greeting("Hola, {$notifiable->name}!")
-            ->line('Tu pago llego despues de que la reserva habia expirado.')
+            ->line('Recibimos tu pago, pero no pudimos completar tu reserva porque ya no se encontraba activa al momento de procesarlo.')
             ->line("Mesa: {$table->name}")
             ->line("Fecha: {$reservation->date->format('d/m/Y')}")
             ->line("Hora: {$reservation->start_time} - {$reservation->end_time}")
-            ->line("Se ha procesado un reembolso automatico de {$formatted} EUR.")
-            ->line('Si deseas, puedes realizar una nueva reserva.');
+            ->line("Hemos procesado un reembolso completo de {$formatted} EUR de forma automatica. Deberia reflejarse en tu cuenta en los proximos dias habiles.")
+            ->line('Si deseas hacer una nueva reserva, puedes hacerlo desde la aplicacion.');
     }
 }

--- a/app/Services/ReservationService.php
+++ b/app/Services/ReservationService.php
@@ -9,7 +9,7 @@ use App\Jobs\ExpireReservationJob;
 use App\Notifications\ReservationCancelledNotification;
 use App\Notifications\GuestReservationConfirmedNotification;
 use App\Notifications\ReservationConfirmedNotification;
-use App\Notifications\ReservationExpiredRefundNotification;
+use App\Notifications\ReservationPaymentRefundedNotification;
 use App\Models\Payment;
 use App\Models\Reservation;
 use App\Models\RestaurantSetting;
@@ -141,11 +141,11 @@ class ReservationService
             return $reservation;
         }
 
-        if ($reservation->status === Reservation::STATUS_EXPIRED) {
+        if ($reservation->status !== Reservation::STATUS_PENDING) {
             $this->paymentService->refund($payment, (float) $payment->amount);
 
             $reservation->user?->notify(
-                new ReservationExpiredRefundNotification($reservation, (float) $payment->amount)
+                new ReservationPaymentRefundedNotification($reservation, (float) $payment->amount)
             );
 
             return $reservation;

--- a/tests/Feature/ReservationNotificationTest.php
+++ b/tests/Feature/ReservationNotificationTest.php
@@ -11,7 +11,7 @@ use App\Notifications\ReservationCancelledNotification;
 use App\Notifications\GuestReservationConfirmedNotification;
 use App\Notifications\ReservationConfirmedNotification;
 use App\Notifications\ReservationExpiredNotification;
-use App\Notifications\ReservationExpiredRefundNotification;
+use App\Notifications\ReservationPaymentRefundedNotification;
 use App\Notifications\ReservationReminderNotification;
 use App\Services\PaymentService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -254,7 +254,7 @@ class ReservationNotificationTest extends TestCase
             'HTTP_STRIPE_SIGNATURE' => 't=123,v1=fake_signature',
         ]);
 
-        Notification::assertSentTo($client, ReservationExpiredRefundNotification::class);
+        Notification::assertSentTo($client, ReservationPaymentRefundedNotification::class);
     }
 
     // ── Expiration ────────────────────────────────────────────

--- a/tests/Feature/StripeWebhookTest.php
+++ b/tests/Feature/StripeWebhookTest.php
@@ -4,8 +4,11 @@ namespace Tests\Feature;
 
 use App\Models\Payment;
 use App\Models\Reservation;
+use App\Notifications\ReservationPaymentRefundedNotification;
+use App\Services\PaymentService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Notification;
 use Stripe\Event;
 use Stripe\Webhook;
 use Tests\TestCase;
@@ -159,5 +162,73 @@ class StripeWebhookTest extends TestCase
 
         $response->assertStatus(200)
             ->assertJson(['received' => true]);
+    }
+
+    public function test_webhook_refunds_and_notifies_when_reservation_is_cancelled(): void
+    {
+        Notification::fake();
+
+        [$reservation, $payment] = $this->createReservationWithPayment(Reservation::STATUS_CANCELLED);
+
+        $payload = $this->webhookPayload($payment->payment_gateway_id);
+
+        $webhookMock = \Mockery::mock('alias:' . Webhook::class);
+        $webhookMock->shouldReceive('constructEvent')
+            ->once()
+            ->andReturn(Event::constructFrom(json_decode($payload, true)));
+
+        $paymentMock = $this->mock(PaymentService::class);
+        $paymentMock->shouldReceive('handleSucceededPayment')->once()->andReturn($payment->fresh());
+        $paymentMock->shouldReceive('refund')->once();
+
+        $response = $this->postJson('/api/stripe/webhook', [], [
+            'HTTP_STRIPE_SIGNATURE' => 't=123,v1=fake_signature',
+        ]);
+
+        $response->assertStatus(200);
+
+        $this->assertDatabaseHas('reservations', [
+            'id' => $reservation->id,
+            'status' => Reservation::STATUS_CANCELLED,
+        ]);
+
+        Notification::assertSentTo(
+            $reservation->user,
+            ReservationPaymentRefundedNotification::class,
+        );
+    }
+
+    public function test_webhook_refunds_and_notifies_when_reservation_is_expired(): void
+    {
+        Notification::fake();
+
+        [$reservation, $payment] = $this->createReservationWithPayment(Reservation::STATUS_EXPIRED);
+
+        $payload = $this->webhookPayload($payment->payment_gateway_id);
+
+        $webhookMock = \Mockery::mock('alias:' . Webhook::class);
+        $webhookMock->shouldReceive('constructEvent')
+            ->once()
+            ->andReturn(Event::constructFrom(json_decode($payload, true)));
+
+        $paymentMock = $this->mock(PaymentService::class);
+        $paymentMock->shouldReceive('handleSucceededPayment')->once()->andReturn($payment->fresh());
+        $paymentMock->shouldReceive('refund')->once();
+
+        $response = $this->postJson('/api/stripe/webhook', [], [
+            'HTTP_STRIPE_SIGNATURE' => 't=123,v1=fake_signature',
+        ]);
+
+        $response->assertStatus(200);
+
+        $this->assertDatabaseHas('reservations', [
+            'id' => $reservation->id,
+            'status' => Reservation::STATUS_EXPIRED,
+        ]);
+
+        Notification::assertSentTo(
+            $reservation->user,
+            ReservationPaymentRefundedNotification::class,
+        );
     }
 }


### PR DESCRIPTION
## Summary

- `confirmPayment` now refunds any reservation that is not `pending` (previously only handled `expired`, leaving `cancelled` reservations with ghost charges)
- Replaced `ReservationExpiredRefundNotification` with `ReservationPaymentRefundedNotification` — single notification for all late-payment refund cases
- Added tests for `cancelled` and `expired` reservation scenarios in `StripeWebhookTest`

## Test plan

- [x] Webhook refunds and notifies when reservation is `expired` at payment time
- [x] Webhook refunds and notifies when reservation is `cancelled` at payment time
- [x] Confirmed reservations still process normally (no refund triggered)
- [x] 258/258 tests passing

Closes #111