### PR TITLE
Fix concurrent pre-orders overselling daily_stock with pessimistic lock

### DIFF
--- a/app/Repositories/MenuItemRepository.php
+++ b/app/Repositories/MenuItemRepository.php
@@ -44,6 +44,11 @@ class MenuItemRepository
         return MenuItem::findOrFail($id);
     }
 
+    public function lockById(int $id): ?MenuItem
+    {
+        return MenuItem::where('id', $id)->lockForUpdate()->first();
+    }
+
     public function create(array $data): MenuItem
     {
         return MenuItem::create($data);

--- a/app/Services/PreOrderService.php
+++ b/app/Services/PreOrderService.php
@@ -27,14 +27,15 @@ class PreOrderService
     public function store(Reservation $reservation, StorePreOrderDTO $dto): ReservationItem
     {
         $this->ensureReservationIsConfirmed($reservation);
+        $this->ensureItemNotAlreadyOrdered($reservation, $dto->menu_item_id);
 
-        $menuItem = $this->menuItemRepository->findOrFail($dto->menu_item_id);
+        return DB::transaction(function () use ($reservation, $dto) {
+            $menuItem = $this->menuItemRepository->lockById($dto->menu_item_id);
 
-        $this->ensureMenuItemIsAvailable($menuItem);
-        $this->ensureMenuItemHasStock($menuItem, $dto->quantity);
-        $this->ensureItemNotAlreadyOrdered($reservation, $menuItem);
+            $this->ensureMenuItemExists($menuItem);
+            $this->ensureMenuItemIsAvailable($menuItem);
+            $this->ensureMenuItemHasStock($menuItem, $dto->quantity);
 
-        return DB::transaction(function () use ($reservation, $menuItem, $dto) {
             $item = $this->reservationItemRepository->create([
                 'reservation_id' => $reservation->id,
                 'menu_item_id' => $menuItem->id,
@@ -94,10 +95,19 @@ class PreOrderService
         }
     }
 
-    private function ensureItemNotAlreadyOrdered(Reservation $reservation, MenuItem $menuItem): void
+    private function ensureMenuItemExists(?MenuItem $menuItem): void
+    {
+        if ($menuItem === null) {
+            throw ValidationException::withMessages([
+                'menu_item_id' => ['El plato seleccionado no existe.'],
+            ]);
+        }
+    }
+
+    private function ensureItemNotAlreadyOrdered(Reservation $reservation, int $menuItemId): void
     {
         $exists = $reservation->reservationItems()
-            ->where('menu_item_id', $menuItem->id)
+            ->where('menu_item_id', $menuItemId)
             ->exists();
 
         if ($exists) {

--- a/tests/Feature/PreOrderTest.php
+++ b/tests/Feature/PreOrderTest.php
@@ -5,7 +5,9 @@ namespace Tests\Feature;
 use App\Models\MenuItem;
 use App\Models\Reservation;
 use App\Models\ReservationItem;
+use App\Repositories\MenuItemRepository;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery;
 use Tests\TestCase;
 use Tests\Traits\CreatesUsers;
 
@@ -227,6 +229,57 @@ class PreOrderTest extends TestCase
 
         $response->assertStatus(422)
             ->assertJsonValidationErrors(['quantity']);
+    }
+
+    // ── Concurrency / locking ─────────────────────────────────
+
+    public function test_store_acquires_pessimistic_lock_on_menu_item_before_decrementing_stock(): void
+    {
+        $client = $this->clientUser();
+        $reservation = Reservation::factory()->confirmed()->create(['user_id' => $client->id]);
+        $menuItem = MenuItem::factory()->create(['daily_stock' => 5]);
+
+        $repositorySpy = Mockery::spy(MenuItemRepository::class)->makePartial();
+        $this->app->instance(MenuItemRepository::class, $repositorySpy);
+
+        $this->actingAs($client)
+            ->postJson("/api/reservations/{$reservation->id}/pre-orders", [
+                'menu_item_id' => $menuItem->id,
+                'quantity' => 1,
+            ])
+            ->assertStatus(201);
+
+        $repositorySpy->shouldHaveReceived('lockById')->with($menuItem->id)->once();
+    }
+
+    public function test_store_rejects_second_order_when_stock_is_exhausted(): void
+    {
+        $client = $this->clientUser();
+        $otherClient = $this->clientUser();
+        $menuItem = MenuItem::factory()->create(['daily_stock' => 1]);
+
+        $firstReservation = Reservation::factory()->confirmed()->create(['user_id' => $client->id]);
+        $secondReservation = Reservation::factory()->confirmed()->create(['user_id' => $otherClient->id]);
+
+        $this->actingAs($client)
+            ->postJson("/api/reservations/{$firstReservation->id}/pre-orders", [
+                'menu_item_id' => $menuItem->id,
+                'quantity' => 1,
+            ])
+            ->assertStatus(201);
+
+        $this->actingAs($otherClient)
+            ->postJson("/api/reservations/{$secondReservation->id}/pre-orders", [
+                'menu_item_id' => $menuItem->id,
+                'quantity' => 1,
+            ])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['quantity']);
+
+        $this->assertDatabaseHas('menu_items', [
+            'id' => $menuItem->id,
+            'daily_stock' => 0,
+        ]);
     }
 
     // ── Destroy ───────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Added `MenuItemRepository::lockById()` to acquire a `SELECT ... FOR UPDATE` lock on the menu item row inside the transaction
- Refactored `PreOrderService::store()` to fetch and validate the menu item inside the transaction using the lock, preventing two concurrent requests from both passing the stock check with the same stale value
- Added `ensureMenuItemExists()` guard for the nullable result of `lockById`
- Updated `ensureItemNotAlreadyOrdered()` signature to receive `int $menuItemId` directly, since it runs before the locked fetch

## Test plan

- [x] `store acquires pessimistic lock on menu item before decrementing stock` — spy verifies `lockById` is called with the correct id
- [x] `store rejects second order when stock is exhausted` — sequential orders with `daily_stock = 1` confirm stock cannot go below 0
- [x] All 22 existing pre-order tests pass without modification

Closes #115