### PR TITLE
Fix race condition between ExpireReservationJob and confirmPayment

### DIFF
--- a/app/Jobs/ExpireReservationJob.php
+++ b/app/Jobs/ExpireReservationJob.php
@@ -9,6 +9,7 @@ use App\Repositories\ReservationRepository;
 use App\Services\PaymentService;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\DB;
 
 class ExpireReservationJob implements ShouldQueue
 {
@@ -18,18 +19,26 @@ class ExpireReservationJob implements ShouldQueue
 
     public function handle(ReservationRepository $reservationRepository, PaymentService $paymentService): void
     {
+        $expiredNow = DB::transaction(function () use ($reservationRepository) {
+            $reservation = $reservationRepository->lockById($this->reservationId);
+
+            if (! $reservation || $reservation->status !== Reservation::STATUS_PENDING) {
+                return false;
+            }
+
+            $reservationRepository->updateStatus($reservation, Reservation::STATUS_EXPIRED);
+
+            return true;
+        });
+
         $reservation = $reservationRepository->find($this->reservationId);
 
         if (! $reservation) {
             return;
         }
 
-        if ($reservation->status === Reservation::STATUS_PENDING) {
-            $reservation = $reservationRepository->updateStatus($reservation, Reservation::STATUS_EXPIRED);
-
-            if ($reservation->user) {
-                $reservation->user->notify(new ReservationExpiredNotification($reservation));
-            }
+        if ($expiredNow && $reservation->user) {
+            $reservation->user->notify(new ReservationExpiredNotification($reservation));
         }
 
         if ($reservation->status !== Reservation::STATUS_EXPIRED) {

--- a/app/Repositories/ReservationRepository.php
+++ b/app/Repositories/ReservationRepository.php
@@ -20,6 +20,11 @@ class ReservationRepository
         return Reservation::find($id);
     }
 
+    public function lockById(int $id): ?Reservation
+    {
+        return Reservation::where('id', $id)->lockForUpdate()->first();
+    }
+
     public function createSnapshot(Reservation $reservation, array $data): CancellationPolicySnapshot
     {
         return $reservation->cancellationPolicySnapshot()->create($data);

--- a/app/Services/ReservationService.php
+++ b/app/Services/ReservationService.php
@@ -141,25 +141,38 @@ class ReservationService
     public function confirmPayment(string $gatewayId): Reservation
     {
         $payment = $this->paymentService->handleSucceededPayment($gatewayId);
-        $reservation = $payment->reservation;
+        $reservationId = $payment->reservation_id;
 
-        if ($reservation->status === Reservation::STATUS_CONFIRMED) {
+        $outcome = DB::transaction(function () use ($reservationId) {
+            $reservation = $this->reservationRepository->lockById($reservationId);
+
+            if ($reservation->status === Reservation::STATUS_CONFIRMED) {
+                return 'already_confirmed';
+            }
+
+            if ($reservation->status !== Reservation::STATUS_PENDING) {
+                return 'must_refund';
+            }
+
+            $this->reservationRepository->updateStatus($reservation, Reservation::STATUS_CONFIRMED);
+
+            return 'confirmed_now';
+        });
+
+        $reservation = $this->reservationRepository->find($reservationId);
+
+        if ($outcome === 'already_confirmed') {
             return $reservation;
         }
 
-        if ($reservation->status !== Reservation::STATUS_PENDING) {
+        if ($outcome === 'must_refund') {
             $this->paymentService->refund($payment, (float) $payment->amount);
-
             $reservation->user?->notify(
                 new ReservationPaymentRefundedNotification($reservation, (float) $payment->amount)
             );
 
             return $reservation;
         }
-
-        $this->reservationRepository->updateStatus($reservation, Reservation::STATUS_CONFIRMED);
-
-        $reservation = $reservation->fresh();
 
         if (! $reservation->user) {
             return $reservation;

--- a/tests/Feature/Jobs/ExpireReservationJobTest.php
+++ b/tests/Feature/Jobs/ExpireReservationJobTest.php
@@ -122,6 +122,45 @@ class ExpireReservationJobTest extends TestCase
         Notification::assertNothingSent();
     }
 
+    public function test_run_on_cancelled_reservation_is_noop(): void
+    {
+        Notification::fake();
+
+        $client = $this->clientUser();
+        $reservation = Reservation::factory()->cancelled()->create(['user_id' => $client->id]);
+        Payment::factory()->for($reservation)->create(['status' => Payment::STATUS_REFUNDED]);
+
+        $this->paymentServiceMock->shouldNotReceive('cancelPaymentIntent');
+
+        $this->runJob($reservation->id);
+
+        $this->assertSame(Reservation::STATUS_CANCELLED, $reservation->fresh()->status);
+        Notification::assertNotSentTo($client, ReservationExpiredNotification::class);
+    }
+
+    public function test_acquires_pessimistic_lock_before_expiring_reservation(): void
+    {
+        Notification::fake();
+
+        $client = $this->clientUser();
+        $reservation = Reservation::factory()->pending()->create(['user_id' => $client->id]);
+
+        $this->paymentServiceMock->shouldNotReceive('cancelPaymentIntent');
+
+        \Illuminate\Support\Facades\DB::flushQueryLog();
+        \Illuminate\Support\Facades\DB::enableQueryLog();
+
+        $this->runJob($reservation->id);
+
+        $queries = collect(\Illuminate\Support\Facades\DB::getQueryLog())
+            ->map(fn ($q) => $q['query']);
+
+        $this->assertTrue(
+            $queries->contains(fn ($q) => str_contains($q, 'for update')),
+            'Expected a lockForUpdate query to be issued'
+        );
+    }
+
     public function test_run_on_pending_reservation_without_payment_only_expires_and_notifies(): void
     {
         Notification::fake();

--- a/tests/Unit/ReservationServiceTest.php
+++ b/tests/Unit/ReservationServiceTest.php
@@ -52,20 +52,26 @@ class ReservationServiceTest extends TestCase
     {
         /** @var Reservation&MockInterface $reservation */
         $reservation = Mockery::mock(Reservation::class)->makePartial();
+        $reservation->id = 1;
         $reservation->status = Reservation::STATUS_PENDING;
 
         /** @var Payment&MockInterface $payment */
         $payment = Mockery::mock(Payment::class)->makePartial();
-        $payment->status = Payment::STATUS_SUCCEEDED;
         $payment->shouldReceive('getAttribute')
-            ->with('reservation')
-            ->andReturn($reservation);
+            ->with('reservation_id')
+            ->andReturn(1);
 
         $this->paymentService
             ->shouldReceive('handleSucceededPayment')
             ->with('pi_test_123')
             ->once()
             ->andReturn($payment);
+
+        $this->reservationRepository
+            ->shouldReceive('lockById')
+            ->with(1)
+            ->once()
+            ->andReturn($reservation);
 
         $this->reservationRepository
             ->shouldReceive('updateStatus')
@@ -75,7 +81,12 @@ class ReservationServiceTest extends TestCase
         /** @var Reservation&MockInterface $freshReservation */
         $freshReservation = Mockery::mock(Reservation::class)->makePartial();
         $freshReservation->status = Reservation::STATUS_CONFIRMED;
-        $reservation->shouldReceive('fresh')->once()->andReturn($freshReservation);
+
+        $this->reservationRepository
+            ->shouldReceive('find')
+            ->with(1)
+            ->once()
+            ->andReturn($freshReservation);
 
         $result = $this->service->confirmPayment('pi_test_123');
 
@@ -86,19 +97,32 @@ class ReservationServiceTest extends TestCase
     {
         /** @var Reservation&MockInterface $reservation */
         $reservation = Mockery::mock(Reservation::class)->makePartial();
+        $reservation->id = 1;
         $reservation->status = Reservation::STATUS_CONFIRMED;
 
         /** @var Payment&MockInterface $payment */
         $payment = Mockery::mock(Payment::class)->makePartial();
         $payment->shouldReceive('getAttribute')
-            ->with('reservation')
-            ->andReturn($reservation);
+            ->with('reservation_id')
+            ->andReturn(1);
 
         $this->paymentService
             ->shouldReceive('handleSucceededPayment')
             ->with('pi_test_123')
             ->once()
             ->andReturn($payment);
+
+        $this->reservationRepository
+            ->shouldReceive('lockById')
+            ->with(1)
+            ->once()
+            ->andReturn($reservation);
+
+        $this->reservationRepository
+            ->shouldReceive('find')
+            ->with(1)
+            ->once()
+            ->andReturn($reservation);
 
         $this->reservationRepository->shouldNotReceive('updateStatus');
         $this->paymentService->shouldNotReceive('refund');
@@ -112,20 +136,33 @@ class ReservationServiceTest extends TestCase
     {
         /** @var Reservation&MockInterface $reservation */
         $reservation = Mockery::mock(Reservation::class)->makePartial();
+        $reservation->id = 1;
         $reservation->status = Reservation::STATUS_EXPIRED;
 
         /** @var Payment&MockInterface $payment */
         $payment = Mockery::mock(Payment::class)->makePartial();
         $payment->amount = '10.00';
         $payment->shouldReceive('getAttribute')
-            ->with('reservation')
-            ->andReturn($reservation);
+            ->with('reservation_id')
+            ->andReturn(1);
 
         $this->paymentService
             ->shouldReceive('handleSucceededPayment')
             ->with('pi_test_123')
             ->once()
             ->andReturn($payment);
+
+        $this->reservationRepository
+            ->shouldReceive('lockById')
+            ->with(1)
+            ->once()
+            ->andReturn($reservation);
+
+        $this->reservationRepository
+            ->shouldReceive('find')
+            ->with(1)
+            ->once()
+            ->andReturn($reservation);
 
         $this->paymentService
             ->shouldReceive('refund')
@@ -137,6 +174,50 @@ class ReservationServiceTest extends TestCase
         $result = $this->service->confirmPayment('pi_test_123');
 
         $this->assertEquals(Reservation::STATUS_EXPIRED, $result->status);
+    }
+
+    public function test_confirm_payment_refunds_when_reservation_cancelled(): void
+    {
+        /** @var Reservation&MockInterface $reservation */
+        $reservation = Mockery::mock(Reservation::class)->makePartial();
+        $reservation->id = 1;
+        $reservation->status = Reservation::STATUS_CANCELLED;
+
+        /** @var Payment&MockInterface $payment */
+        $payment = Mockery::mock(Payment::class)->makePartial();
+        $payment->amount = '25.00';
+        $payment->shouldReceive('getAttribute')
+            ->with('reservation_id')
+            ->andReturn(1);
+
+        $this->paymentService
+            ->shouldReceive('handleSucceededPayment')
+            ->with('pi_test_123')
+            ->once()
+            ->andReturn($payment);
+
+        $this->reservationRepository
+            ->shouldReceive('lockById')
+            ->with(1)
+            ->once()
+            ->andReturn($reservation);
+
+        $this->reservationRepository
+            ->shouldReceive('find')
+            ->with(1)
+            ->once()
+            ->andReturn($reservation);
+
+        $this->paymentService
+            ->shouldReceive('refund')
+            ->with($payment, 25.00)
+            ->once();
+
+        $this->reservationRepository->shouldNotReceive('updateStatus');
+
+        $result = $this->service->confirmPayment('pi_test_123');
+
+        $this->assertEquals(Reservation::STATUS_CANCELLED, $result->status);
     }
 
     // ── cancel ───────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Added `ReservationRepository::lockById` to acquire a `SELECT ... FOR UPDATE` row-level lock on a reservation
- Wrapped the status check + update in `ExpireReservationJob` inside `DB::transaction` with `lockById`, so the job cannot overwrite a reservation that was confirmed concurrently by the Stripe webhook
- Wrapped the reservation status check + update in `ReservationService::confirmPayment` inside `DB::transaction` with `lockById`, ensuring both sides serialize through the same lock — without this, the job's lock alone does not prevent the webhook's plain UPDATE from overwriting after the lock releases
- Stripe API calls (`cancelPaymentIntent`, `refund`) and notifications kept outside the transaction to avoid holding locks during external I/O

## Test plan

- [x] `ExpireReservationJob`: 8 tests pass, including new `test_run_on_cancelled_reservation_is_noop` and `test_acquires_pessimistic_lock_before_expiring_reservation` (verifies `FOR UPDATE` query is issued via query log)
- [x] `ReservationServiceTest`: 15 tests pass, including updated mocks for `lockById`/`find` and new `test_confirm_payment_refunds_when_reservation_cancelled`
- [x] Full suite: 265 tests, 868 assertions — no regressions
- [x] Retry-safety preserved: job with `status=expired` + `payment=pending` still cancels the orphaned payment intent

Closes #117