### PR TITLE
Fix stuck pending payments by handling payment_intent.payment_failed

### DIFF
--- a/app/Http/Controllers/StripeWebhookController.php
+++ b/app/Http/Controllers/StripeWebhookController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Exceptions\PaymentNotFoundException;
+use App\Services\PaymentService;
 use App\Services\ReservationService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -12,7 +13,10 @@ use Stripe\Webhook;
 
 class StripeWebhookController extends Controller
 {
-    public function __construct(private ReservationService $reservationService) {}
+    public function __construct(
+        private ReservationService $reservationService,
+        private PaymentService $paymentService,
+    ) {}
 
     public function handle(Request $request): JsonResponse
     {
@@ -26,13 +30,20 @@ class StripeWebhookController extends Controller
             return response()->json(['error' => 'Firma invalida.'], 403);
         }
 
-        if ($event->type === 'payment_intent.succeeded') {
-            try {
-                $gatewayId = $event->data->object->id;
-                $this->reservationService->confirmPayment($gatewayId);
-            } catch (PaymentNotFoundException $e) {
-                Log::warning("Stripe webhook: {$e->getMessage()}");
-            }
+        $intent = $event->data->object;
+
+        try {
+            match ($event->type) {
+                'payment_intent.succeeded' => $this->reservationService->confirmPayment($intent->id),
+                'payment_intent.payment_failed' => $this->paymentService->handleFailedPayment(
+                    $intent->id,
+                    $intent->last_payment_error?->code,
+                    $intent->last_payment_error?->message,
+                ),
+                default => null,
+            };
+        } catch (PaymentNotFoundException $e) {
+            Log::warning("Stripe webhook: {$e->getMessage()}");
         }
 
         return response()->json(['received' => true]);

--- a/app/Services/PaymentService.php
+++ b/app/Services/PaymentService.php
@@ -5,6 +5,7 @@ namespace App\Services;
 use App\Exceptions\PaymentNotFoundException;
 use App\Models\Payment;
 use App\Repositories\PaymentRepository;
+use Illuminate\Support\Facades\Log;
 use Stripe\PaymentIntent;
 use Stripe\Refund;
 
@@ -54,6 +55,35 @@ class PaymentService
         $this->paymentRepository->update($payment, [
             'status' => Payment::STATUS_SUCCEEDED,
             'paid_at' => now(),
+        ]);
+
+        return $payment->fresh();
+    }
+
+    public function handleFailedPayment(
+        string $gatewayId,
+        ?string $errorCode = null,
+        ?string $errorMessage = null,
+    ): Payment {
+        $payment = $this->paymentRepository->findByGatewayId($gatewayId);
+
+        if (! $payment) {
+            throw new PaymentNotFoundException($gatewayId);
+        }
+
+        if ($payment->status !== Payment::STATUS_PENDING) {
+            return $payment;
+        }
+
+        $this->paymentRepository->update($payment, [
+            'status' => Payment::STATUS_FAILED,
+        ]);
+
+        Log::warning('Stripe payment failed', [
+            'payment_id' => $payment->id,
+            'gateway_id' => $gatewayId,
+            'error_code' => $errorCode,
+            'error_message' => $errorMessage,
         ]);
 
         return $payment->fresh();

--- a/tests/Feature/StripeWebhookTest.php
+++ b/tests/Feature/StripeWebhookTest.php
@@ -36,19 +36,28 @@ class StripeWebhookTest extends TestCase
         return [$reservation, $payment];
     }
 
-    private function webhookPayload(string $gatewayId, string $type = 'payment_intent.succeeded'): string
-    {
+    private function webhookPayload(
+        string $gatewayId,
+        string $type = 'payment_intent.succeeded',
+        ?array $lastPaymentError = null,
+    ): string {
+        $object = [
+            'id' => $gatewayId,
+            'object' => 'payment_intent',
+            'amount' => 1000,
+            'currency' => 'eur',
+            'status' => 'succeeded',
+        ];
+
+        if ($lastPaymentError !== null) {
+            $object['last_payment_error'] = $lastPaymentError;
+        }
+
         return json_encode([
             'id' => 'evt_test_' . uniqid(),
             'type' => $type,
             'data' => [
-                'object' => [
-                    'id' => $gatewayId,
-                    'object' => 'payment_intent',
-                    'amount' => 1000,
-                    'currency' => 'eur',
-                    'status' => 'succeeded',
-                ],
+                'object' => $object,
             ],
         ]);
     }
@@ -230,5 +239,160 @@ class StripeWebhookTest extends TestCase
             $reservation->user,
             ReservationPaymentRefundedNotification::class,
         );
+    }
+
+    public function test_webhook_marks_payment_as_failed_on_payment_failed(): void
+    {
+        [$reservation, $payment] = $this->createReservationWithPayment();
+
+        $payload = $this->webhookPayload(
+            $payment->payment_gateway_id,
+            'payment_intent.payment_failed',
+            ['code' => 'card_declined', 'message' => 'Your card was declined.'],
+        );
+
+        $mock = \Mockery::mock('alias:' . Webhook::class);
+        $mock->shouldReceive('constructEvent')
+            ->once()
+            ->andReturn(Event::constructFrom(json_decode($payload, true)));
+
+        $response = $this->postJson('/api/stripe/webhook', [], [
+            'HTTP_STRIPE_SIGNATURE' => 't=123,v1=fake_signature',
+        ]);
+
+        $response->assertStatus(200)->assertJson(['received' => true]);
+
+        $this->assertDatabaseHas('payments', [
+            'id' => $payment->id,
+            'status' => Payment::STATUS_FAILED,
+        ]);
+
+        $this->assertDatabaseHas('reservations', [
+            'id' => $reservation->id,
+            'status' => Reservation::STATUS_PENDING,
+        ]);
+    }
+
+    public function test_webhook_does_not_overwrite_succeeded_payment_on_payment_failed(): void
+    {
+        [$reservation, $payment] = $this->createReservationWithPayment(Reservation::STATUS_CONFIRMED);
+
+        $payment->update([
+            'status' => Payment::STATUS_SUCCEEDED,
+            'paid_at' => now(),
+        ]);
+
+        $payload = $this->webhookPayload(
+            $payment->payment_gateway_id,
+            'payment_intent.payment_failed',
+            ['code' => 'card_declined', 'message' => 'Card declined.'],
+        );
+
+        $mock = \Mockery::mock('alias:' . Webhook::class);
+        $mock->shouldReceive('constructEvent')
+            ->once()
+            ->andReturn(Event::constructFrom(json_decode($payload, true)));
+
+        $response = $this->postJson('/api/stripe/webhook', [], [
+            'HTTP_STRIPE_SIGNATURE' => 't=123,v1=fake_signature',
+        ]);
+
+        $response->assertStatus(200);
+
+        $this->assertDatabaseHas('payments', [
+            'id' => $payment->id,
+            'status' => Payment::STATUS_SUCCEEDED,
+        ]);
+
+        $this->assertDatabaseHas('reservations', [
+            'id' => $reservation->id,
+            'status' => Reservation::STATUS_CONFIRMED,
+        ]);
+    }
+
+    public function test_webhook_is_idempotent_for_already_failed_payment(): void
+    {
+        [, $payment] = $this->createReservationWithPayment();
+
+        $payment->update(['status' => Payment::STATUS_FAILED]);
+
+        $payload = $this->webhookPayload(
+            $payment->payment_gateway_id,
+            'payment_intent.payment_failed',
+            ['code' => 'card_declined', 'message' => 'Card declined.'],
+        );
+
+        $mock = \Mockery::mock('alias:' . Webhook::class);
+        $mock->shouldReceive('constructEvent')
+            ->once()
+            ->andReturn(Event::constructFrom(json_decode($payload, true)));
+
+        $response = $this->postJson('/api/stripe/webhook', [], [
+            'HTTP_STRIPE_SIGNATURE' => 't=123,v1=fake_signature',
+        ]);
+
+        $response->assertStatus(200);
+
+        $this->assertDatabaseHas('payments', [
+            'id' => $payment->id,
+            'status' => Payment::STATUS_FAILED,
+        ]);
+    }
+
+    public function test_webhook_logs_error_details_on_payment_failed(): void
+    {
+        [, $payment] = $this->createReservationWithPayment();
+
+        $payload = $this->webhookPayload(
+            $payment->payment_gateway_id,
+            'payment_intent.payment_failed',
+            ['code' => 'card_declined', 'message' => 'Your card was declined.'],
+        );
+
+        $mock = \Mockery::mock('alias:' . Webhook::class);
+        $mock->shouldReceive('constructEvent')
+            ->once()
+            ->andReturn(Event::constructFrom(json_decode($payload, true)));
+
+        Log::shouldReceive('warning')
+            ->once()
+            ->withArgs(function (string $message, array $context) use ($payment) {
+                return $message === 'Stripe payment failed'
+                    && $context['payment_id'] === $payment->id
+                    && $context['gateway_id'] === $payment->payment_gateway_id
+                    && $context['error_code'] === 'card_declined'
+                    && $context['error_message'] === 'Your card was declined.';
+            });
+
+        $response = $this->postJson('/api/stripe/webhook', [], [
+            'HTTP_STRIPE_SIGNATURE' => 't=123,v1=fake_signature',
+        ]);
+
+        $response->assertStatus(200);
+    }
+
+    public function test_webhook_returns_200_when_payment_not_found_on_failed(): void
+    {
+        $nonExistentGatewayId = 'pi_non_existent_456';
+        $payload = $this->webhookPayload(
+            $nonExistentGatewayId,
+            'payment_intent.payment_failed',
+            ['code' => 'card_declined', 'message' => 'Card declined.'],
+        );
+
+        $mock = \Mockery::mock('alias:' . Webhook::class);
+        $mock->shouldReceive('constructEvent')
+            ->once()
+            ->andReturn(Event::constructFrom(json_decode($payload, true)));
+
+        Log::shouldReceive('warning')
+            ->once()
+            ->withArgs(fn (string $message) => str_contains($message, $nonExistentGatewayId));
+
+        $response = $this->postJson('/api/stripe/webhook', [], [
+            'HTTP_STRIPE_SIGNATURE' => 't=123,v1=fake_signature',
+        ]);
+
+        $response->assertStatus(200)->assertJson(['received' => true]);
     }
 }

--- a/tests/Unit/PaymentServiceTest.php
+++ b/tests/Unit/PaymentServiceTest.php
@@ -1,0 +1,195 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Exceptions\PaymentNotFoundException;
+use App\Models\Payment;
+use App\Repositories\PaymentRepository;
+use App\Services\PaymentService;
+use Illuminate\Support\Facades\Log;
+use Mockery;
+use Mockery\MockInterface;
+use Tests\TestCase;
+
+class PaymentServiceTest extends TestCase
+{
+    private PaymentService $service;
+    private PaymentRepository&MockInterface $paymentRepository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->paymentRepository = Mockery::mock(PaymentRepository::class);
+        $this->service = new PaymentService($this->paymentRepository);
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    // ── handleFailedPayment ──────────────────────────────────────
+
+    public function test_handle_failed_payment_throws_when_payment_not_found(): void
+    {
+        $this->paymentRepository
+            ->shouldReceive('findByGatewayId')
+            ->with('pi_missing')
+            ->once()
+            ->andReturn(null);
+
+        $this->expectException(PaymentNotFoundException::class);
+
+        $this->service->handleFailedPayment('pi_missing');
+    }
+
+    public function test_handle_failed_payment_updates_status_to_failed_when_pending(): void
+    {
+        $payment = $this->makePaymentMock(Payment::STATUS_PENDING);
+
+        $this->paymentRepository
+            ->shouldReceive('findByGatewayId')
+            ->with('pi_pending_1')
+            ->once()
+            ->andReturn($payment);
+
+        $this->paymentRepository
+            ->shouldReceive('update')
+            ->with($payment, ['status' => Payment::STATUS_FAILED])
+            ->once();
+
+        Log::shouldReceive('warning')->once();
+
+        $result = $this->service->handleFailedPayment('pi_pending_1');
+
+        $this->assertSame($payment, $result);
+    }
+
+    public function test_handle_failed_payment_logs_error_details_with_stripe_payload(): void
+    {
+        $payment = $this->makePaymentMock(
+            status: Payment::STATUS_PENDING,
+            paymentId: 42,
+            gatewayId: 'pi_pending_2',
+        );
+
+        $this->paymentRepository
+            ->shouldReceive('findByGatewayId')
+            ->with('pi_pending_2')
+            ->once()
+            ->andReturn($payment);
+
+        $this->paymentRepository
+            ->shouldReceive('update')
+            ->once();
+
+        Log::shouldReceive('warning')
+            ->once()
+            ->withArgs(function (string $message, array $context) {
+                return $message === 'Stripe payment failed'
+                    && $context['payment_id'] === 42
+                    && $context['gateway_id'] === 'pi_pending_2'
+                    && $context['error_code'] === 'card_declined'
+                    && $context['error_message'] === 'Your card was declined.';
+            });
+
+        $result = $this->service->handleFailedPayment(
+            'pi_pending_2',
+            'card_declined',
+            'Your card was declined.',
+        );
+
+        $this->assertSame($payment, $result);
+    }
+
+    public function test_handle_failed_payment_logs_with_null_error_fields_when_stripe_omits_them(): void
+    {
+        $payment = $this->makePaymentMock(Payment::STATUS_PENDING);
+
+        $this->paymentRepository
+            ->shouldReceive('findByGatewayId')
+            ->once()
+            ->andReturn($payment);
+
+        $this->paymentRepository
+            ->shouldReceive('update')
+            ->once();
+
+        Log::shouldReceive('warning')
+            ->once()
+            ->withArgs(fn (string $message, array $context) => $context['error_code'] === null
+                && $context['error_message'] === null);
+
+        $result = $this->service->handleFailedPayment('pi_no_error');
+
+        $this->assertSame($payment, $result);
+    }
+
+    public function test_handle_failed_payment_is_no_op_when_payment_already_succeeded(): void
+    {
+        $payment = $this->makePaymentMock(Payment::STATUS_SUCCEEDED);
+
+        $this->paymentRepository
+            ->shouldReceive('findByGatewayId')
+            ->with('pi_succeeded')
+            ->once()
+            ->andReturn($payment);
+
+        $this->paymentRepository->shouldNotReceive('update');
+
+        $result = $this->service->handleFailedPayment('pi_succeeded');
+
+        $this->assertSame($payment, $result);
+    }
+
+    public function test_handle_failed_payment_is_no_op_when_payment_already_failed(): void
+    {
+        $payment = $this->makePaymentMock(Payment::STATUS_FAILED);
+
+        $this->paymentRepository
+            ->shouldReceive('findByGatewayId')
+            ->with('pi_failed')
+            ->once()
+            ->andReturn($payment);
+
+        $this->paymentRepository->shouldNotReceive('update');
+
+        $result = $this->service->handleFailedPayment('pi_failed');
+
+        $this->assertSame($payment, $result);
+    }
+
+    public function test_handle_failed_payment_is_no_op_when_payment_refunded(): void
+    {
+        $payment = $this->makePaymentMock(Payment::STATUS_REFUNDED);
+
+        $this->paymentRepository
+            ->shouldReceive('findByGatewayId')
+            ->with('pi_refunded')
+            ->once()
+            ->andReturn($payment);
+
+        $this->paymentRepository->shouldNotReceive('update');
+
+        $result = $this->service->handleFailedPayment('pi_refunded');
+
+        $this->assertSame($payment, $result);
+    }
+
+    private function makePaymentMock(
+        string $status,
+        int $paymentId = 1,
+        string $gatewayId = 'pi_test',
+    ): Payment&MockInterface {
+        /** @var Payment&MockInterface $payment */
+        $payment = Mockery::mock(Payment::class)->makePartial();
+        $payment->shouldReceive('getAttribute')->with('status')->andReturn($status);
+        $payment->shouldReceive('getAttribute')->with('id')->andReturn($paymentId);
+        $payment->shouldReceive('getAttribute')->with('payment_gateway_id')->andReturn($gatewayId);
+        $payment->shouldReceive('fresh')->andReturnSelf();
+
+        return $payment;
+    }
+}


### PR DESCRIPTION
## Summary

- Add `PaymentService::handleFailedPayment` to mark payment as `failed` on Stripe `payment_intent.payment_failed`, with guard clause to stay idempotent and avoid overwriting a `succeeded` payment when events arrive out of order
- Route the new event from `StripeWebhookController` (refactored to a `match` expression with a single shared `PaymentNotFoundException` handler) — reservation status is intentionally untouched so the customer can still retry within the same `PaymentIntent`
- Log Stripe's `last_payment_error.code` and `message` for audit and pattern detection

## Test plan

- [x] `PaymentServiceTest` (unit, 7 cases): not-found exception, pending → failed transition, logging payload (with and without Stripe error), no-op on succeeded/failed/refunded
- [x] `StripeWebhookTest` (feature, 5 new cases): success path, no-overwrite of succeeded (race protection), idempotency on already-failed, error logging, 200 when payment not found
- [x] Full suite: 277 passed, 894 assertions

Closes #119