### PR TITLE
Add Stripe idempotency_key to createPaymentIntent

### DIFF
--- a/app/Services/PaymentService.php
+++ b/app/Services/PaymentService.php
@@ -26,6 +26,8 @@ class PaymentService
             'metadata' => [
                 'reservation_id' => $reservationId,
             ],
+        ], [
+            'idempotency_key' => "reservation_{$reservationId}_payment_intent",
         ]);
 
         $payment = $this->paymentRepository->create([

--- a/tests/Unit/PaymentServiceTest.php
+++ b/tests/Unit/PaymentServiceTest.php
@@ -9,6 +9,8 @@ use App\Services\PaymentService;
 use Illuminate\Support\Facades\Log;
 use Mockery;
 use Mockery\MockInterface;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use Tests\TestCase;
 
 class PaymentServiceTest extends TestCase
@@ -28,6 +30,48 @@ class PaymentServiceTest extends TestCase
     {
         Mockery::close();
         parent::tearDown();
+    }
+
+    // ── createPaymentIntent ──────────────────────────────────────
+
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function test_create_payment_intent_passes_idempotency_key_derived_from_reservation_id(): void
+    {
+        $reservationId = 42;
+        $expectedKey = "reservation_{$reservationId}_payment_intent";
+
+        $intent = (object) [
+            'id' => 'pi_idempotent_test',
+            'client_secret' => 'secret_xyz',
+        ];
+
+        $stripeMock = Mockery::mock('alias:Stripe\PaymentIntent');
+        $stripeMock
+            ->shouldReceive('create')
+            ->once()
+            ->withArgs(function (array $params, array $options) use ($expectedKey, $reservationId) {
+                return $options['idempotency_key'] === $expectedKey
+                    && $params['amount'] === 2550
+                    && $params['metadata']['reservation_id'] === $reservationId;
+            })
+            ->andReturn($intent);
+
+        $payment = Mockery::mock(Payment::class);
+        $this->paymentRepository
+            ->shouldReceive('create')
+            ->once()
+            ->with([
+                'reservation_id' => $reservationId,
+                'amount' => 25.50,
+                'payment_gateway_id' => 'pi_idempotent_test',
+            ])
+            ->andReturn($payment);
+
+        $result = $this->service->createPaymentIntent($reservationId, 25.50);
+
+        $this->assertSame($payment, $result['payment']);
+        $this->assertSame('secret_xyz', $result['client_secret']);
     }
 
     // ── handleFailedPayment ──────────────────────────────────────


### PR DESCRIPTION
## Summary

- Pass `idempotency_key` to `Stripe\PaymentIntent::create` with deterministic format `reservation_{id}_payment_intent`
- Prevents duplicate `PaymentIntent` resources when the Stripe call is retried (network timeout, SDK retry, frontend re-submit)
- One reservation = one initial PaymentIntent — Stripe collides repeated calls on the same key within 24h
- Add unit test in `PaymentServiceTest` verifying the key format and Stripe call arguments
- Test uses Mockery alias mock with `#[RunInSeparateProcess]` + `#[PreserveGlobalState(false)]` to avoid the loaded-class issue documented in project memory

## Test plan

- [x] New unit test `test_create_payment_intent_passes_idempotency_key_derived_from_reservation_id` passes
- [x] Full suite passes: 278/278 tests (+1 new)
- [x] No existing feature tests broken (they mock `PaymentService::createPaymentIntent`, so the internal Stripe signature change is transparent)

Closes #121