### PR TITLE
Block email update from profile endpoint

### DIFF
--- a/app/DTOs/UpdateProfileDTO.php
+++ b/app/DTOs/UpdateProfileDTO.php
@@ -7,7 +7,6 @@ readonly class UpdateProfileDTO
     public function __construct(
         public int $user_id,
         public ?string $name = null,
-        public ?string $email = null,
         public ?string $phone = null,
         private array $presentFields = [],
     ) {}
@@ -17,7 +16,6 @@ readonly class UpdateProfileDTO
         return new self(
             user_id: $userId,
             name: $validated['name'] ?? null,
-            email: $validated['email'] ?? null,
             phone: $validated['phone'] ?? null,
             presentFields: array_keys($validated),
         );
@@ -26,7 +24,7 @@ readonly class UpdateProfileDTO
     public function userData(): array
     {
         return array_filter(
-            ['name' => $this->name, 'email' => $this->email],
+            ['name' => $this->name],
             fn (mixed $value, string $key) => in_array($key, $this->presentFields),
             ARRAY_FILTER_USE_BOTH,
         );

--- a/app/Http/Requests/UpdateProfileRequest.php
+++ b/app/Http/Requests/UpdateProfileRequest.php
@@ -3,7 +3,6 @@
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
-use Illuminate\Validation\Rule;
 
 class UpdateProfileRequest extends FormRequest
 {
@@ -16,7 +15,6 @@ class UpdateProfileRequest extends FormRequest
     {
         return [
             'name'  => ['sometimes', 'string', 'max:255'],
-            'email' => ['sometimes', 'string', 'email', 'max:255', Rule::unique('users')->ignore($this->user()->id)],
             'phone' => ['sometimes', 'nullable', 'string', 'regex:/^[6-9]\d{8}$/'],
         ];
     }

--- a/tests/Feature/ProfileTest.php
+++ b/tests/Feature/ProfileTest.php
@@ -88,15 +88,17 @@ class ProfileTest extends TestCase
         $this->assertDatabaseHas('users', ['id' => $user->id, 'name' => 'Nuevo Nombre']);
     }
 
-    public function test_client_can_update_email(): void
+    public function test_email_is_not_updated_when_sent_in_request(): void
     {
         $user = $this->clientWithProfile();
+        $original = $user->email;
 
-        $response = $this->actingAs($user)
-            ->putJson('/api/profile', ['email' => 'nuevo@example.com']);
+        $this->actingAs($user)
+            ->putJson('/api/profile', ['email' => 'nuevo@example.com'])
+            ->assertStatus(200)
+            ->assertJsonPath('data.email', $original);
 
-        $response->assertStatus(200)
-            ->assertJsonPath('data.email', 'nuevo@example.com');
+        $this->assertDatabaseHas('users', ['id' => $user->id, 'email' => $original]);
     }
 
     public function test_client_can_update_phone(): void
@@ -119,13 +121,11 @@ class ProfileTest extends TestCase
         $response = $this->actingAs($user)
             ->putJson('/api/profile', [
                 'name' => 'Otro Nombre',
-                'email' => 'otro@example.com',
                 'phone' => '699999999',
             ]);
 
         $response->assertStatus(200)
             ->assertJsonPath('data.name', 'Otro Nombre')
-            ->assertJsonPath('data.email', 'otro@example.com')
             ->assertJsonPath('data.phone', '699999999');
     }
 
@@ -160,28 +160,6 @@ class ProfileTest extends TestCase
 
         $response->assertStatus(200)
             ->assertJsonPath('data.phone', null);
-    }
-
-    public function test_update_rejects_duplicate_email(): void
-    {
-        User::factory()->create(['email' => 'taken@example.com']);
-        $user = $this->clientWithProfile();
-
-        $response = $this->actingAs($user)
-            ->putJson('/api/profile', ['email' => 'taken@example.com']);
-
-        $response->assertStatus(422)
-            ->assertJsonValidationErrors(['email']);
-    }
-
-    public function test_update_allows_own_email(): void
-    {
-        $user = $this->clientWithProfile();
-
-        $response = $this->actingAs($user)
-            ->putJson('/api/profile', ['email' => $user->email]);
-
-        $response->assertStatus(200);
     }
 
     public function test_admin_can_update_profile(): void


### PR DESCRIPTION
## Summary

- Removed `email` from `UpdateProfileRequest` validation rules — the field is now silently ignored if sent in the request body
- Removed `email` from `UpdateProfileDTO` constructor, `fromValidated()`, and `userData()` — defense in depth so the field never reaches the repository layer
- Removed `use Illuminate\Validation\Rule` import, now unused

## Test plan

- [x] `test_email_is_not_updated_when_sent_in_request` — sends a different email, asserts response and DB both retain the original
- [x] `test_client_can_update_multiple_fields` — removed email from payload and assertions
- [x] Removed `test_client_can_update_email`, `test_update_rejects_duplicate_email`, `test_update_allows_own_email` — these tested a behaviour that no longer exists
- [x] 276 tests passing (276/276)

Closes #123