### PR TITLE
Fix orphaned Stripe intents from cancelPaymentIntent

### DIFF
--- a/app/Jobs/ExpireReservationJob.php
+++ b/app/Jobs/ExpireReservationJob.php
@@ -10,6 +10,7 @@ use App\Services\PaymentService;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 
 class ExpireReservationJob implements ShouldQueue
 {
@@ -48,7 +49,15 @@ class ExpireReservationJob implements ShouldQueue
         $payment = $reservation->payment;
 
         if ($payment && $payment->status === Payment::STATUS_PENDING) {
-            $paymentService->cancelPaymentIntent($payment);
+            try {
+                $paymentService->cancelPaymentIntent($payment);
+            } catch (\Exception $e) {
+                Log::error('Failed to cancel PaymentIntent on reservation expiration', [
+                    'reservation_id' => $this->reservationId,
+                    'payment_id' => $payment->id,
+                    'gateway_id' => $payment->payment_gateway_id,
+                ]);
+            }
         }
     }
 }

--- a/app/Services/ReservationService.php
+++ b/app/Services/ReservationService.php
@@ -20,6 +20,7 @@ use Carbon\Carbon;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Validation\ValidationException;
 
 class ReservationService
@@ -129,7 +130,14 @@ class ReservationService
         });
 
         if ($previousPayment) {
-            $this->paymentService->cancelPaymentIntent($previousPayment);
+            try {
+                $this->paymentService->cancelPaymentIntent($previousPayment);
+            } catch (\Exception $e) {
+                Log::error('Failed to cancel orphaned PaymentIntent on new hold', [
+                    'payment_id' => $previousPayment->id,
+                    'gateway_id' => $previousPayment->payment_gateway_id,
+                ]);
+            }
         }
 
         ExpireReservationJob::dispatch($result['reservation']->id)
@@ -200,36 +208,60 @@ class ReservationService
 
         $reservationDateTime = Carbon::parse($reservation->date->format('Y-m-d') . ' ' . $reservation->start_time);
 
-        $refundAmount = DB::transaction(function () use ($reservation, $reservationDateTime) {
+        $pendingAction = DB::transaction(function () use ($reservation, $reservationDateTime) {
             $this->reservationRepository->updateStatus($reservation, Reservation::STATUS_CANCELLED);
 
             $payment = $reservation->payment;
 
             if (! $payment) {
-                return null;
+                return ['action' => 'none'];
             }
 
             if ($payment->status === Payment::STATUS_PENDING) {
-                $this->paymentService->cancelPaymentIntent($payment);
-
-                return null;
+                return ['action' => 'cancel', 'payment' => $payment];
             }
 
             if ($payment->status !== Payment::STATUS_SUCCEEDED) {
-                return null;
+                return ['action' => 'none'];
             }
 
             $snapshot = $reservation->cancellationPolicySnapshot;
             $hoursUntilReservation = now()->diffInHours($reservationDateTime, false);
 
-            $refundAmount = $hoursUntilReservation >= $snapshot->cancellation_deadline_hours
+            $amount = $hoursUntilReservation >= $snapshot->cancellation_deadline_hours
                 ? (float) $payment->amount
                 : (float) $payment->amount * $snapshot->refund_percentage / 100;
 
-            $this->paymentService->refund($payment, $refundAmount);
-
-            return $refundAmount;
+            return ['action' => 'refund', 'payment' => $payment, 'amount' => $amount];
         });
+
+        $refundAmount = null;
+
+        if ($pendingAction['action'] === 'cancel') {
+            try {
+                $this->paymentService->cancelPaymentIntent($pendingAction['payment']);
+            } catch (\Exception $e) {
+                Log::error('Failed to cancel PaymentIntent on reservation cancellation', [
+                    'reservation_id' => $reservation->id,
+                    'payment_id' => $pendingAction['payment']->id,
+                    'gateway_id' => $pendingAction['payment']->payment_gateway_id,
+                ]);
+            }
+        }
+
+        if ($pendingAction['action'] === 'refund') {
+            try {
+                $this->paymentService->refund($pendingAction['payment'], $pendingAction['amount']);
+                $refundAmount = $pendingAction['amount'];
+            } catch (\Exception $e) {
+                Log::error('Failed to refund payment on reservation cancellation', [
+                    'reservation_id' => $reservation->id,
+                    'payment_id' => $pendingAction['payment']->id,
+                    'gateway_id' => $pendingAction['payment']->payment_gateway_id,
+                    'amount' => $pendingAction['amount'],
+                ]);
+            }
+        }
 
         $reservation = $reservation->fresh();
 

--- a/tests/Feature/Jobs/ExpireReservationJobTest.php
+++ b/tests/Feature/Jobs/ExpireReservationJobTest.php
@@ -175,4 +175,30 @@ class ExpireReservationJobTest extends TestCase
         $this->assertSame(Reservation::STATUS_EXPIRED, $reservation->fresh()->status);
         Notification::assertSentToTimes($client, ReservationExpiredNotification::class, 1);
     }
+
+    public function test_stripe_failure_on_cancel_is_logged_and_job_completes(): void
+    {
+        Notification::fake();
+
+        $client = $this->clientUser();
+        $reservation = Reservation::factory()->pending()->create(['user_id' => $client->id]);
+        $payment = Payment::factory()->for($reservation)->create();
+
+        $this->paymentServiceMock
+            ->shouldReceive('cancelPaymentIntent')
+            ->once()
+            ->andThrow(new \Exception('Stripe unavailable'));
+
+        \Illuminate\Support\Facades\Log::shouldReceive('error')
+            ->once()
+            ->with('Failed to cancel PaymentIntent on reservation expiration', Mockery::subset([
+                'reservation_id' => $reservation->id,
+                'payment_id' => $payment->id,
+            ]));
+
+        $this->runJob($reservation->id);
+
+        $this->assertSame(Reservation::STATUS_EXPIRED, $reservation->fresh()->status);
+        $this->assertSame(Payment::STATUS_PENDING, $payment->fresh()->status);
+    }
 }

--- a/tests/Feature/ReservationTest.php
+++ b/tests/Feature/ReservationTest.php
@@ -298,6 +298,81 @@ class ReservationTest extends TestCase
         ]);
     }
 
+    public function test_hold_succeeds_and_logs_error_when_cancel_previous_intent_fails(): void
+    {
+        Queue::fake();
+
+        $this->paymentServiceMock
+            ->shouldReceive('createPaymentIntent')
+            ->twice()
+            ->andReturn(
+                [
+                    'payment' => new Payment([
+                        'amount' => 10.00,
+                        'status' => Payment::STATUS_PENDING,
+                        'payment_gateway_id' => 'pi_test_first',
+                    ]),
+                    'client_secret' => 'pi_test_first_secret',
+                ],
+                [
+                    'payment' => new Payment([
+                        'amount' => 10.00,
+                        'status' => Payment::STATUS_PENDING,
+                        'payment_gateway_id' => 'pi_test_second',
+                    ]),
+                    'client_secret' => 'pi_test_second_secret',
+                ],
+            );
+
+        $this->paymentServiceMock
+            ->shouldReceive('cancelPaymentIntent')
+            ->once()
+            ->andThrow(new \Exception('Stripe unavailable'));
+
+        \Illuminate\Support\Facades\Log::shouldReceive('error')
+            ->once()
+            ->with('Failed to cancel orphaned PaymentIntent on new hold', Mockery::type('array'));
+
+        $client = $this->clientUser();
+        $firstTable = Table::factory()->create();
+        $date = now()->addDays(3)->format('Y-m-d');
+
+        $this->actingAs($client)->postJson('/api/reservations', [
+            'table_id' => $firstTable->id,
+            'seats_requested' => 2,
+            'date' => $date,
+            'start_time' => '20:00',
+        ]);
+
+        $firstReservation = Reservation::where('user_id', $client->id)->first();
+
+        Payment::create([
+            'reservation_id' => $firstReservation->id,
+            'amount' => 10.00,
+            'status' => Payment::STATUS_PENDING,
+            'payment_gateway_id' => 'pi_test_first',
+        ]);
+
+        $secondTable = Table::factory()->create();
+
+        $response = $this->actingAs($client)
+            ->postJson('/api/reservations', [
+                'table_id' => $secondTable->id,
+                'seats_requested' => 2,
+                'date' => $date,
+                'start_time' => '20:00',
+            ]);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('data.client_secret', 'pi_test_second_secret');
+
+        $this->assertDatabaseHas('reservations', [
+            'table_id' => $secondTable->id,
+            'user_id' => $client->id,
+            'status' => Reservation::STATUS_PENDING,
+        ]);
+    }
+
     public function test_hold_rejects_overlapping_reservation_on_same_table(): void
     {
         Queue::fake();
@@ -626,12 +701,16 @@ class ReservationTest extends TestCase
         $this->assertDatabaseCount('cancellation_policy_snapshots', 0);
     }
 
-    public function test_cancel_does_not_change_status_when_stripe_refund_fails(): void
+    public function test_cancel_cancels_reservation_and_logs_error_when_stripe_refund_fails(): void
     {
         $this->paymentServiceMock
             ->shouldReceive('refund')
             ->once()
             ->andThrow(new \Exception('Stripe refund error'));
+
+        \Illuminate\Support\Facades\Log::shouldReceive('error')
+            ->once()
+            ->with('Failed to refund payment on reservation cancellation', Mockery::type('array'));
 
         $client = $this->clientUser();
         $reservation = Reservation::factory()->withCancellationPolicy()->create([
@@ -643,11 +722,11 @@ class ReservationTest extends TestCase
         $response = $this->actingAs($client)
             ->postJson("/api/reservations/{$reservation->id}/cancel");
 
-        $response->assertStatus(500);
+        $response->assertStatus(200);
 
         $this->assertDatabaseHas('reservations', [
             'id' => $reservation->id,
-            'status' => Reservation::STATUS_CONFIRMED,
+            'status' => Reservation::STATUS_CANCELLED,
         ]);
     }
 

--- a/tests/Unit/ReservationServiceTest.php
+++ b/tests/Unit/ReservationServiceTest.php
@@ -351,6 +351,106 @@ class ReservationServiceTest extends TestCase
         $this->service->cancel($reservation);
     }
 
+    public function test_cancel_logs_error_when_cancel_payment_intent_fails(): void
+    {
+        /** @var Reservation&MockInterface $reservation */
+        $reservation = Mockery::mock(Reservation::class)->makePartial();
+        $reservation->id = 1;
+        $reservation->status = Reservation::STATUS_PENDING;
+        $reservation->date = new \DateTime(now()->addDays(3)->format('Y-m-d'));
+        $reservation->start_time = '20:00:00';
+
+        /** @var Payment&MockInterface $payment */
+        $payment = Mockery::mock(Payment::class)->makePartial();
+        $payment->id = 1;
+        $payment->status = Payment::STATUS_PENDING;
+        $payment->payment_gateway_id = 'pi_test_123';
+
+        $reservation->shouldReceive('getAttribute')->with('payment')->andReturn($payment);
+
+        $this->reservationRepository
+            ->shouldReceive('updateStatus')
+            ->with($reservation, Reservation::STATUS_CANCELLED)
+            ->once();
+
+        $this->paymentService
+            ->shouldReceive('cancelPaymentIntent')
+            ->with($payment)
+            ->once()
+            ->andThrow(new \Exception('Stripe unavailable'));
+
+        /** @var Reservation&MockInterface $freshReservation */
+        $freshReservation = Mockery::mock(Reservation::class)->makePartial();
+        $freshReservation->status = Reservation::STATUS_CANCELLED;
+        $reservation->shouldReceive('fresh')->once()->andReturn($freshReservation);
+
+        \Illuminate\Support\Facades\Log::shouldReceive('error')
+            ->once()
+            ->with('Failed to cancel PaymentIntent on reservation cancellation', Mockery::subset([
+                'reservation_id' => 1,
+                'payment_id' => 1,
+                'gateway_id' => 'pi_test_123',
+            ]));
+
+        $result = $this->service->cancel($reservation);
+
+        $this->assertEquals(Reservation::STATUS_CANCELLED, $result->status);
+    }
+
+    public function test_cancel_logs_error_when_refund_fails(): void
+    {
+        /** @var Reservation&MockInterface $reservation */
+        $reservation = Mockery::mock(Reservation::class)->makePartial();
+        $reservation->id = 1;
+        $reservation->status = Reservation::STATUS_CONFIRMED;
+        $reservation->date = new \DateTime(now()->addDays(3)->format('Y-m-d'));
+        $reservation->start_time = '20:00:00';
+
+        /** @var CancellationPolicySnapshot&MockInterface $snapshot */
+        $snapshot = Mockery::mock(CancellationPolicySnapshot::class)->makePartial();
+        $snapshot->cancellation_deadline_hours = 24;
+        $snapshot->refund_percentage = 50;
+
+        /** @var Payment&MockInterface $payment */
+        $payment = Mockery::mock(Payment::class)->makePartial();
+        $payment->id = 1;
+        $payment->status = Payment::STATUS_SUCCEEDED;
+        $payment->amount = '10.00';
+        $payment->payment_gateway_id = 'pi_test_456';
+
+        $reservation->shouldReceive('getAttribute')->with('payment')->andReturn($payment);
+        $reservation->shouldReceive('getAttribute')->with('cancellationPolicySnapshot')->andReturn($snapshot);
+
+        $this->reservationRepository
+            ->shouldReceive('updateStatus')
+            ->with($reservation, Reservation::STATUS_CANCELLED)
+            ->once();
+
+        $this->paymentService
+            ->shouldReceive('refund')
+            ->with($payment, 10.00)
+            ->once()
+            ->andThrow(new \Exception('Stripe unavailable'));
+
+        /** @var Reservation&MockInterface $freshReservation */
+        $freshReservation = Mockery::mock(Reservation::class)->makePartial();
+        $freshReservation->status = Reservation::STATUS_CANCELLED;
+        $reservation->shouldReceive('fresh')->once()->andReturn($freshReservation);
+
+        \Illuminate\Support\Facades\Log::shouldReceive('error')
+            ->once()
+            ->with('Failed to refund payment on reservation cancellation', Mockery::subset([
+                'reservation_id' => 1,
+                'payment_id' => 1,
+                'gateway_id' => 'pi_test_456',
+                'amount' => 10.00,
+            ]));
+
+        $result = $this->service->cancel($reservation);
+
+        $this->assertEquals(Reservation::STATUS_CANCELLED, $result->status);
+    }
+
     // ── markAsNoShow ─────────────────────────────────────────
 
     public function test_mark_as_no_show_changes_completed_to_no_show(): void


### PR DESCRIPTION
## Summary

- `ReservationService::cancel`: Stripe calls (`cancelPaymentIntent`, `refund`) moved outside `DB::transaction`. The transaction now returns an action descriptor and commits only DB changes; Stripe is called after the commit with `try/catch + Log::error`
- `ReservationService::hold`: wrapped `cancelPaymentIntent` of the previous payment in `try/catch + Log::error` so a Stripe failure does not abort the new hold
- `ExpireReservationJob`: same `try/catch + Log::error` pattern so a Stripe failure does not propagate and the job completes normally
- All three Stripe failure scenarios log the `payment_gateway_id` for manual resolution

## Test plan

- [x] `ReservationServiceTest`: 2 new unit tests — `cancelPaymentIntent` throws → reservation cancelled, error logged; `refund` throws → reservation cancelled, error logged
- [x] `ReservationTest`: 1 new feature test — Stripe failure on previous hold cancel → new hold succeeds, error logged; existing `test_cancel_does_not_change_status_when_stripe_refund_fails` updated to reflect new behavior (200 + `cancelled`)
- [x] `ExpireReservationJobTest`: 1 new test — Stripe failure → job completes, reservation stays `expired`, payment stays `pending`, error logged
- [x] Full suite: 280/280 passing

Closes #125