### PR TITLE
Introduce ClientProfileRepository to centralize client_profiles persistence

### DIFF
--- a/app/Repositories/ClientProfileRepository.php
+++ b/app/Repositories/ClientProfileRepository.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Repositories;
+
+use App\Models\ClientProfile;
+use App\Models\User;
+
+class ClientProfileRepository
+{
+    public function create(User $user, array $data): ClientProfile
+    {
+        return $user->clientProfile()->create($data);
+    }
+
+    public function update(ClientProfile $profile, array $data): ClientProfile
+    {
+        $profile->update($data);
+
+        return $profile->fresh();
+    }
+}

--- a/app/Services/AuthService.php
+++ b/app/Services/AuthService.php
@@ -10,6 +10,7 @@ use App\DTOs\ResetPasswordDTO;
 use App\Models\User;
 use App\Notifications\AccountCompletionNotification;
 use App\Notifications\ResetPasswordNotification;
+use App\Repositories\ClientProfileRepository;
 use App\Repositories\UserRepository;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
@@ -20,7 +21,8 @@ use Laravel\Sanctum\PersonalAccessToken;
 class AuthService
 {
     public function __construct(
-        private UserRepository $userRepository
+        private UserRepository $userRepository,
+        private ClientProfileRepository $clientProfileRepository,
     ) {}
 
     public function register(RegisterDTO $dto): array
@@ -33,7 +35,7 @@ class AuthService
             ]);
 
             $user->assignRole('client');
-            $user->clientProfile()->create(['phone' => $dto->phone]);
+            $this->clientProfileRepository->create($user, ['phone' => $dto->phone]);
 
             return $user;
         });

--- a/app/Services/GuestReservationService.php
+++ b/app/Services/GuestReservationService.php
@@ -5,6 +5,7 @@ namespace App\Services;
 use App\DTOs\GuestHoldReservationDTO;
 use App\DTOs\HoldReservationDTO;
 use App\Models\User;
+use App\Repositories\ClientProfileRepository;
 use App\Repositories\UserRepository;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\ValidationException;
@@ -14,6 +15,7 @@ class GuestReservationService
     public function __construct(
         private UserRepository $userRepository,
         private ReservationService $reservationService,
+        private ClientProfileRepository $clientProfileRepository,
     ) {}
 
     public function hold(GuestHoldReservationDTO $dto): array
@@ -52,7 +54,7 @@ class GuestReservationService
             ]);
 
             $user->assignRole('client');
-            $user->clientProfile()->create(['phone' => $dto->phone]);
+            $this->clientProfileRepository->create($user, ['phone' => $dto->phone]);
 
             return $user;
         });

--- a/app/Services/ProfileService.php
+++ b/app/Services/ProfileService.php
@@ -5,11 +5,15 @@ namespace App\Services;
 use App\DTOs\UpdatePasswordDTO;
 use App\DTOs\UpdateProfileDTO;
 use App\Models\User;
+use App\Repositories\ClientProfileRepository;
 use App\Repositories\UserRepository;
 
 class ProfileService
 {
-    public function __construct(private UserRepository $repository) {}
+    public function __construct(
+        private UserRepository $repository,
+        private ClientProfileRepository $clientProfileRepository,
+    ) {}
 
     public function get(int $userId): User
     {
@@ -26,7 +30,7 @@ class ProfileService
         }
 
         if ($dto->hasPhone() && $user->clientProfile) {
-            $user->clientProfile->update(['phone' => $dto->phone]);
+            $this->clientProfileRepository->update($user->clientProfile, ['phone' => $dto->phone]);
         }
 
         return $user->fresh('clientProfile');

--- a/tests/Feature/ClientProfileRepositoryTest.php
+++ b/tests/Feature/ClientProfileRepositoryTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\ClientProfile;
+use App\Repositories\ClientProfileRepository;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use Tests\Traits\CreatesUsers;
+
+class ClientProfileRepositoryTest extends TestCase
+{
+    use RefreshDatabase;
+    use CreatesUsers;
+
+    private ClientProfileRepository $repository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(\Database\Seeders\RoleSeeder::class);
+        $this->repository = app(ClientProfileRepository::class);
+    }
+
+    public function test_create_persists_profile_linked_to_user(): void
+    {
+        $user = $this->clientUser();
+
+        $profile = $this->repository->create($user, ['phone' => '612345678']);
+
+        $this->assertInstanceOf(ClientProfile::class, $profile);
+        $this->assertSame($user->id, $profile->user_id);
+        $this->assertSame('612345678', $profile->phone);
+        $this->assertDatabaseHas('client_profiles', [
+            'user_id' => $user->id,
+            'phone'   => '612345678',
+        ]);
+    }
+
+    public function test_update_changes_phone_and_returns_fresh_profile(): void
+    {
+        $user = $this->clientUser();
+        $profile = $this->repository->create($user, ['phone' => '612345678']);
+
+        $updated = $this->repository->update($profile, ['phone' => '698765432']);
+
+        $this->assertSame('698765432', $updated->phone);
+        $this->assertDatabaseHas('client_profiles', [
+            'user_id' => $user->id,
+            'phone'   => '698765432',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ClientProfileRepository` with `create(User, array)` and `update(ClientProfile, array)`, encapsulating all access to the `client_profiles` table
- `ProfileService` now updates profiles through the repository instead of `$user->clientProfile->update(...)`
- `AuthService` and `GuestReservationService` now create profiles through the repository instead of `$user->clientProfile()->create(...)`
- Restores the Repository pattern boundary that every other model already follows; no service writes to `client_profiles` directly anymore

## Test plan
- [x] New `ClientProfileRepositoryTest` covers `create` (persists profile linked to user) and `update` (changes phone, returns fresh)
- [x] Existing `ProfileTest`, `AuthTest` and `GuestReservationTest` stay green
- [x] Full suite: 283 passed (916 assertions)

Closes #131