### PR TITLE
Replace per-row UPDATE loop with bulk update in AutoCompleteReservationsJob

### DIFF
--- a/app/Jobs/AutoCompleteReservationsJob.php
+++ b/app/Jobs/AutoCompleteReservationsJob.php
@@ -2,7 +2,6 @@
 
 namespace App\Jobs;
 
-use App\Models\Reservation;
 use App\Repositories\ReservationRepository;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -16,10 +15,6 @@ class AutoCompleteReservationsJob implements ShouldQueue
 
     public function handle(ReservationRepository $reservationRepository): void
     {
-        $reservations = $reservationRepository->findCompletable();
-
-        foreach ($reservations as $reservation) {
-            $reservationRepository->updateStatus($reservation, Reservation::STATUS_COMPLETED);
-        }
+        $reservationRepository->completeDue();
     }
 }

--- a/app/Repositories/ReservationRepository.php
+++ b/app/Repositories/ReservationRepository.php
@@ -84,15 +84,14 @@ class ReservationRepository
         $reservation->update(['reminder_sent_at' => now()]);
     }
 
-    public function findCompletable(): Collection
+    public function completeDue(): int
     {
         return Reservation::where('status', Reservation::STATUS_CONFIRMED)
             ->whereRaw(
                 'CAST(date AS timestamp) + end_time < ?',
                 [now()]
             )
-            ->with('table')
-            ->get();
+            ->update(['status' => Reservation::STATUS_COMPLETED]);
     }
 
     public function findDueForReminder(int $reminderHours): Collection


### PR DESCRIPTION
## Summary
- Replace the row-by-row update in `AutoCompleteReservationsJob` (1 + 2M queries per run) with a single set-based `UPDATE`
- Rename `ReservationRepository::findCompletable()` to `completeDue(): int`, returning the affected row count
- Drop the dead `with('table')` eager-load (audit finding A-8)
- The `confirmed -> completed` transition has no side effects (no notifications, Stripe calls, or model observers), so the atomic bulk update is behavior-preserving

## Test plan
- [x] `AutoCompleteReservationsJobTest` (4 tests) passes unchanged — completes past end-time, ignores in-progress, ignores non-confirmed statuses, handles multiple in one run
- [x] Full suite green (283 tests, 916 assertions)

Closes #133