### PR TITLE
Align guest phone validation with registered-user regex

### DIFF
--- a/app/Http/Requests/GuestHoldReservationRequest.php
+++ b/app/Http/Requests/GuestHoldReservationRequest.php
@@ -16,7 +16,7 @@ class GuestHoldReservationRequest extends FormRequest
         return [
             'name' => ['required', 'string', 'max:255'],
             'email' => ['required', 'string', 'email', 'max:255'],
-            'phone' => ['required', 'string', 'max:20'],
+            'phone' => ['required', 'string', 'regex:/^[6-9]\d{8}$/'],
             'table_id' => ['required', 'integer', 'exists:tables,id'],
             'seats_requested' => ['required', 'integer', 'min:1'],
             'date' => ['required', 'date_format:Y-m-d'],

--- a/tests/Feature/GuestReservationTest.php
+++ b/tests/Feature/GuestReservationTest.php
@@ -36,7 +36,7 @@ class GuestReservationTest extends TestCase
         return array_merge([
             'name' => 'Juan Perez',
             'email' => 'juan@example.com',
-            'phone' => '+34612345678',
+            'phone' => '612345678',
             'table_id' => Table::factory()->create()->id,
             'seats_requested' => 2,
             'date' => now()->addDays(3)->format('Y-m-d'),
@@ -85,7 +85,7 @@ class GuestReservationTest extends TestCase
         ]);
 
         $this->assertDatabaseHas('client_profiles', [
-            'phone' => '+34612345678',
+            'phone' => '612345678',
         ]);
 
         $this->assertDatabaseHas('reservations', [
@@ -118,7 +118,7 @@ class GuestReservationTest extends TestCase
 
         $lazyUser = User::create(['name' => 'Juan Perez', 'email' => 'lazy@example.com']);
         $lazyUser->assignRole('client');
-        $lazyUser->clientProfile()->create(['phone' => '+34612345678']);
+        $lazyUser->clientProfile()->create(['phone' => '612345678']);
 
         $table = Table::factory()->create();
 
@@ -146,6 +146,18 @@ class GuestReservationTest extends TestCase
 
         $response->assertStatus(422)
             ->assertJsonValidationErrors(['name', 'email', 'phone', 'table_id', 'seats_requested', 'date', 'start_time']);
+    }
+
+    public function test_guest_hold_rejects_invalid_phone_format(): void
+    {
+        $this->paymentServiceMock->shouldNotReceive('createPaymentIntent');
+
+        $response = $this->postJson('/api/guest/reservations', $this->guestHoldData([
+            'phone' => '+34612345678',
+        ]));
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['phone']);
     }
 
     public function test_guest_hold_cancels_previous_pending_and_creates_new(): void


### PR DESCRIPTION
## Summary
- Replace the loose `max:20` phone rule in `GuestHoldReservationRequest` with `regex:/^[6-9]\d{8}$/`, matching `RegisterRequest` and `UpdateProfileRequest`
- Guarantees guest and registered phones share one Spanish format, preventing heterogeneous data in the `phone` column
- Update existing guest test fixtures from `+34612345678` to a valid `612345678`
- Add `test_guest_hold_rejects_invalid_phone_format` to cover 422 rejection of malformed phones

## Test plan
- [x] `php artisan test tests/Feature/GuestReservationTest.php` — 7 passed (48 assertions)
- [x] New test rejects `+34612345678` with 422 and `phone` validation error
- [x] Happy-path guest hold still creates reservation with valid phone

Closes #137
