### PR TITLE
Move confirmedReservationsForCapacity to ReservationRepository

### DIFF
--- a/app/Repositories/ReservationRepository.php
+++ b/app/Repositories/ReservationRepository.php
@@ -4,6 +4,7 @@ namespace App\Repositories;
 
 use App\Models\CancellationPolicySnapshot;
 use App\Models\Reservation;
+use App\Models\Table;
 use Carbon\Carbon;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Eloquent\Collection;
@@ -70,6 +71,14 @@ class ReservationRepository
     public function findExpired(): Collection
     {
         return Reservation::expired()->get();
+    }
+
+    public function confirmedReservationsForCapacity(int $seatsRequested, string $date): \Illuminate\Support\Collection
+    {
+        return Reservation::confirmed()
+            ->where('date', $date)
+            ->whereIn('table_id', Table::matchingCapacity($seatsRequested)->select('id'))
+            ->get(['table_id', 'start_time', 'end_time']);
     }
 
     public function updateStatus(Reservation $reservation, string $status): Reservation

--- a/app/Repositories/TableRepository.php
+++ b/app/Repositories/TableRepository.php
@@ -51,14 +51,6 @@ class TableRepository
         return Table::matchingCapacity($seatsRequested)->count();
     }
 
-    public function confirmedReservationsForCapacity(int $seatsRequested, string $date): \Illuminate\Support\Collection
-    {
-        return Reservation::confirmed()
-            ->where('date', $date)
-            ->whereIn('table_id', Table::matchingCapacity($seatsRequested)->select('id'))
-            ->get(['table_id', 'start_time', 'end_time']);
-    }
-
     public function findAvailable(int $seatsRequested, string $date, string $startTime, string $endTime): Collection
     {
         return Table::matchingCapacity($seatsRequested)

--- a/app/Services/ReservationService.php
+++ b/app/Services/ReservationService.php
@@ -316,7 +316,7 @@ class ReservationService
             return [];
         }
 
-        $reservations = $this->tableRepository->confirmedReservationsForCapacity(
+        $reservations = $this->reservationRepository->confirmedReservationsForCapacity(
             $dto->seats_requested,
             $dto->date
         );


### PR DESCRIPTION
## Summary

- Move `confirmedReservationsForCapacity()` from `TableRepository` to `ReservationRepository`, where the query's root model (`Reservation`) belongs
- Fix the cross-domain leak: the `Table` repository was owning a `Reservation` query
- Update the caller in `ReservationService::getTimeSlots()` to use the correct repository
- Symmetric with `findAvailable()` (root `Table`) staying in `TableRepository`
- Pure refactor: no behavior change

## Test plan

- [x] `TimeSlotsTest` green (14 passed, 41 assertions)
- [x] Slot blocking by confirmed reservations still works
- [x] Pending/cancelled/expired reservations do not block slots

Closes #139