### PR TITLE
Remove unused fresh() call from ReservationRepository::updateStatus

### DIFF
--- a/app/Repositories/ReservationRepository.php
+++ b/app/Repositories/ReservationRepository.php
@@ -81,11 +81,9 @@ class ReservationRepository
             ->get(['table_id', 'start_time', 'end_time']);
     }
 
-    public function updateStatus(Reservation $reservation, string $status): Reservation
+    public function updateStatus(Reservation $reservation, string $status): void
     {
         $reservation->update(['status' => $status]);
-
-        return $reservation->fresh();
     }
 
     public function markReminderSent(Reservation $reservation): void


### PR DESCRIPTION
## Summary
- `updateStatus()` now returns `void`; removed the `$reservation->fresh()` call
- The refreshed model was never consumed by any of the five callers, so the extra `SELECT` on each status transition was dead work
- `update()` already mutates the in-memory `status`, so callers remain correct without the round-trip

## Test plan
- [x] `ReservationServiceTest` (confirm, cancel, no_show, releasePendingHold paths)
- [x] `ExpireReservationJob` tests
- [x] `TimeSlotsTest`
- [x] Full filtered suite: 40 passed (84 assertions)

Closes #141