### PR TITLE
Migrate Table model casts to casts() method

### DIFF
--- a/app/Models/Table.php
+++ b/app/Models/Table.php
@@ -19,9 +19,12 @@ class Table extends Model
         'is_active',
     ];
 
-    protected $casts = [
-        'is_active' => 'boolean',
-    ];
+    protected function casts(): array
+    {
+        return [
+            'is_active' => 'boolean',
+        ];
+    }
 
     public function scopeMatchingCapacity(Builder $query, int $seatsRequested): Builder
     {


### PR DESCRIPTION
## Summary
Replaces the legacy `protected $casts` property in the `Table` model with the modern `protected function casts(): array` method (Laravel 11+), aligning it with the other 7 models in the codebase.

The method form is evaluated at runtime, allowing logic (constants, conditionals, cast factories) where the static property cannot. This change is consistency-only — no behavior change.

## Changes
- `app/Models/Table.php`: `$casts` property → `casts()` method returning `['is_active' => 'boolean']`

## Verification
- No `protected $casts` legacy property remains in `app/Models/`
- Test suite: 34 passed (107 assertions)

Closes #143