### PR TITLE
Modernize legacy queue traits in jobs to Foundation\Queue\Queueable

### DIFF
--- a/app/Jobs/AutoCompleteReservationsJob.php
+++ b/app/Jobs/AutoCompleteReservationsJob.php
@@ -3,15 +3,12 @@
 namespace App\Jobs;
 
 use App\Repositories\ReservationRepository;
-use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Foundation\Bus\Dispatchable;
-use Illuminate\Queue\InteractsWithQueue;
-use Illuminate\Queue\SerializesModels;
+use Illuminate\Foundation\Queue\Queueable;
 
 class AutoCompleteReservationsJob implements ShouldQueue
 {
-    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+    use Queueable;
 
     public function handle(ReservationRepository $reservationRepository): void
     {

--- a/app/Jobs/SendReservationRemindersJob.php
+++ b/app/Jobs/SendReservationRemindersJob.php
@@ -5,15 +5,12 @@ namespace App\Jobs;
 use App\Notifications\ReservationReminderNotification;
 use App\Repositories\ReservationRepository;
 use App\Repositories\RestaurantSettingRepository;
-use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Foundation\Bus\Dispatchable;
-use Illuminate\Queue\InteractsWithQueue;
-use Illuminate\Queue\SerializesModels;
+use Illuminate\Foundation\Queue\Queueable;
 
 class SendReservationRemindersJob implements ShouldQueue
 {
-    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+    use Queueable;
 
     public function handle(
         RestaurantSettingRepository $settingRepository,


### PR DESCRIPTION
## Summary
- Replace the four legacy queue traits (`Dispatchable`, `InteractsWithQueue`, `Bus\Queueable`, `SerializesModels`) in `AutoCompleteReservationsJob` and `SendReservationRemindersJob` with the single `Illuminate\Foundation\Queue\Queueable` trait
- Aligns both jobs with `ExpireReservationJob`, which already uses the modern trait
- No behavior change

## Test plan
- [x] `php artisan test` — 284 passed
- [x] Job-specific tests (`AutoCompleteReservationsJobTest`, `ReservationNotificationTest`) green

Closes #145