### PR TITLE
Wrap webhook signature error in API error contract

### DIFF
--- a/app/Http/Controllers/StripeWebhookController.php
+++ b/app/Http/Controllers/StripeWebhookController.php
@@ -27,7 +27,12 @@ class StripeWebhookController extends Controller
                 config('services.stripe.webhook_secret'),
             );
         } catch (SignatureVerificationException $e) {
-            return response()->json(['error' => 'Firma invalida.'], 403);
+            return response()->json([
+                'error' => [
+                    'code' => 'INVALID_SIGNATURE',
+                    'message' => 'Firma inválida.',
+                ],
+            ], 403);
         }
 
         $intent = $event->data->object;

--- a/tests/Feature/StripeWebhookTest.php
+++ b/tests/Feature/StripeWebhookTest.php
@@ -103,7 +103,12 @@ class StripeWebhookTest extends TestCase
         ]);
 
         $response->assertStatus(403)
-            ->assertJson(['error' => 'Firma invalida.']);
+            ->assertJson([
+                'error' => [
+                    'code' => 'INVALID_SIGNATURE',
+                    'message' => 'Firma inválida.',
+                ],
+            ]);
     }
 
     public function test_webhook_is_idempotent_for_already_confirmed_reservation(): void


### PR DESCRIPTION
## Summary
- Return the 403 signature-verification failure in `StripeWebhookController` as `{ "error": { "code": "INVALID_SIGNATURE", "message": "Firma inválida." } }` instead of a flat error string, matching the project's API error contract
- Introduce the first `error.code` (`INVALID_SIGNATURE`) in the project, setting the SCREAMING_SNAKE_CASE precedent
- Fix the Spanish diacritic in the message (`inválida`)
- No status or behavior change (still 403); only the body shape

## Test plan
- [x] `StripeWebhookTest::test_webhook_rejects_invalid_signature` updated to assert the new shape
- [x] StripeWebhookTest suite green (12 passed)
- [x] Full suite green (284 passed)

Closes #147