### PR TITLE
Remove dead guest fields from Reservation and fix admin search

### DIFF
--- a/app/Filament/Resources/ReservationResource.php
+++ b/app/Filament/Resources/ReservationResource.php
@@ -41,12 +41,9 @@ class ReservationResource extends Resource
             ->columns([
                 TextColumn::make('client_name')
                     ->label('Cliente')
-                    ->getStateUsing(fn (Reservation $record): string => $record->user?->name ?? $record->guest_name ?? '-')
+                    ->getStateUsing(fn (Reservation $record): string => $record->user?->name ?? '-')
                     ->searchable(query: function ($query, string $search): void {
-                        $query->where(function ($query) use ($search) {
-                            $query->whereHas('user', fn ($q) => $q->where('name', 'ilike', "%{$search}%"))
-                                ->orWhere('guest_name', 'ilike', "%{$search}%");
-                        });
+                        $query->whereHas('user', fn ($q) => $q->where('name', 'ilike', "%{$search}%"));
                     }),
 
                 TextColumn::make('table.name')

--- a/app/Models/Reservation.php
+++ b/app/Models/Reservation.php
@@ -21,9 +21,6 @@ class Reservation extends Model
 
     protected $fillable = [
         'user_id',
-        'guest_name',
-        'guest_email',
-        'guest_phone',
         'table_id',
         'seats_requested',
         'date',

--- a/tests/Feature/ReservationResourceTest.php
+++ b/tests/Feature/ReservationResourceTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Filament\Resources\ReservationResource\Pages\ListReservations;
 use App\Models\Reservation;
+use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Livewire\Livewire;
 use Tests\TestCase;
@@ -31,6 +32,25 @@ class ReservationResourceTest extends TestCase
         Livewire::actingAs($admin)
             ->test(ListReservations::class)
             ->assertCanSeeTableRecords([$reservation]);
+    }
+
+    public function test_admin_can_search_reservations_by_client_name(): void
+    {
+        $admin = $this->adminUser();
+
+        $matching = Reservation::factory()->confirmed()->create([
+            'user_id' => User::factory()->create(['name' => 'Maria Gomez']),
+        ]);
+
+        $other = Reservation::factory()->confirmed()->create([
+            'user_id' => User::factory()->create(['name' => 'Carlos Ruiz']),
+        ]);
+
+        Livewire::actingAs($admin)
+            ->test(ListReservations::class)
+            ->searchTable('Maria')
+            ->assertCanSeeTableRecords([$matching])
+            ->assertCanNotSeeTableRecords([$other]);
     }
 
     public function test_no_show_action_is_visible_for_completed_reservations(): void


### PR DESCRIPTION
## Summary
- Remove `guest_name`, `guest_email`, `guest_phone` from `Reservation::$fillable` — the `reservations` table has no such columns and no service writes them. Guest data lives on the `User`/`ClientProfile` records, linked via `user_id` (see `GuestReservationService::resolveUser`).
- Fix the Filament `ReservationResource` admin search: it ran `orWhere('guest_name', ...)` against a nonexistent column, producing SQL that crashed the reservation search on PostgreSQL (`column "guest_name" does not exist`).
- Drop the now-redundant `?? $record->guest_name` display fallback (covered by `$record->user?->name`). Guest names remain searchable through the existing `whereHas('user')` clause.

## Test plan
- [x] Added `test_admin_can_search_reservations_by_client_name` exercising the previously crashing search query
- [x] Existing `ReservationResourceTest` suite green (5 passed)
- [x] Full suite green (285 passed, 922 assertions)

Closes #149