### PR TITLE
Add partial expression indexes for due-reservation queries

### DIFF
--- a/database/migrations/2026_06_15_100000_add_due_reservation_indexes_to_reservations_table.php
+++ b/database/migrations/2026_06_15_100000_add_due_reservation_indexes_to_reservations_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        DB::statement("
+            CREATE INDEX idx_reservations_due_completion
+            ON reservations ((CAST(date AS timestamp) + end_time))
+            WHERE status = 'confirmed'
+        ");
+
+        DB::statement("
+            CREATE INDEX idx_reservations_due_reminder
+            ON reservations ((CAST(date AS timestamp) + start_time))
+            WHERE status = 'confirmed' AND reminder_sent_at IS NULL
+        ");
+    }
+
+    public function down(): void
+    {
+        DB::statement('DROP INDEX IF EXISTS idx_reservations_due_completion');
+        DB::statement('DROP INDEX IF EXISTS idx_reservations_due_reminder');
+    }
+};


### PR DESCRIPTION
## Summary

`AutoCompleteReservationsJob` and `SendReservationRemindersJob` run periodically and trigger two queries that scanned `reservations` inefficiently. Both range predicates filter on the **expression** `CAST(date AS timestamp) + time`, which a plain composite b-tree over the raw columns cannot serve — Postgres cannot use independent columns of a composite index to resolve an expression that combines them.

This adds two **partial expression indexes**, scoped to `status='confirmed'` (the only candidate rows), matching each query exactly:

- `idx_reservations_due_completion` — `(CAST(date AS timestamp) + end_time)` WHERE `status='confirmed'`
- `idx_reservations_due_reminder` — `(CAST(date AS timestamp) + start_time)` WHERE `status='confirmed' AND reminder_sent_at IS NULL`

No changes to `ReservationRepository` or business logic — the existing queries already match the indexed expressions.

## Verification

`EXPLAIN ANALYZE` against a seeded dataset (8050 rows, 50 `confirmed`) confirms both new indexes are used and the expression resolves as **`Index Cond`** (not a post-scan Filter):

```
completeDue        -> Index Scan using idx_reservations_due_completion
                      Index Cond: ((date::timestamp + end_time::interval) < now())
findDueForReminder -> Index Scan using idx_reservations_due_reminder
                      Index Cond: (range on date::timestamp + start_time::interval)
```

The partial predicate means `status='confirmed'` / `reminder_sent_at IS NULL` are baked into the index and don't even appear as filter conditions.

## Tests

- Full suite green: 285 passed (922 assertions)
- Migration runs clean against the test database

Closes #151