### PR TITLE
Extract AlignedToInterval rule to remove duplicated interval-alignment logic

### DIFF
--- a/app/Http/Requests/UpdateRestaurantSettingRequest.php
+++ b/app/Http/Requests/UpdateRestaurantSettingRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests;
 
+use App\Rules\AlignedToInterval;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
@@ -35,20 +36,13 @@ class UpdateRestaurantSettingRequest extends FormRequest
                 $closing = $this->input('closing_time', $settings->closing_time);
                 $interval = (int) $this->input('time_slot_interval_minutes', $settings->time_slot_interval_minutes);
 
-                $openingMinutes = $this->toMinutes($opening);
-                $closingMinutes = $this->toMinutes($closing);
-
-                if ($openingMinutes >= $closingMinutes) {
+                if ($this->toMinutes($opening) >= $this->toMinutes($closing)) {
                     $validator->errors()->add('opening_time', 'La hora de apertura debe ser anterior a la hora de cierre.');
                 }
 
-                if ($openingMinutes % $interval !== 0) {
-                    $validator->errors()->add('opening_time', "La hora de apertura debe estar alineada a intervalos de {$interval} minutos.");
-                }
-
-                if ($closingMinutes % $interval !== 0) {
-                    $validator->errors()->add('closing_time', "La hora de cierre debe estar alineada a intervalos de {$interval} minutos.");
-                }
+                $alignedToInterval = new AlignedToInterval($interval);
+                $alignedToInterval->validate('opening_time', $opening, fn ($message) => $validator->errors()->add('opening_time', $message));
+                $alignedToInterval->validate('closing_time', $closing, fn ($message) => $validator->errors()->add('closing_time', $message));
             },
         ];
     }

--- a/app/Rules/AlignedToInterval.php
+++ b/app/Rules/AlignedToInterval.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Support\Carbon;
+
+class AlignedToInterval implements ValidationRule
+{
+    public function __construct(private readonly int $interval)
+    {
+    }
+
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (! is_string($value) || $value === '') {
+            return;
+        }
+
+        $time = Carbon::parse($value);
+        $totalMinutes = $time->hour * 60 + $time->minute;
+
+        if ($totalMinutes % $this->interval !== 0) {
+            $fail("Debe estar alineada a intervalos de {$this->interval} minutos.");
+        }
+    }
+}

--- a/app/Services/ReservationService.php
+++ b/app/Services/ReservationService.php
@@ -16,11 +16,13 @@ use App\Models\RestaurantSetting;
 use App\Repositories\ReservationRepository;
 use App\Repositories\RestaurantSettingRepository;
 use App\Repositories\TableRepository;
+use App\Rules\AlignedToInterval;
 use Carbon\Carbon;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\ValidationException;
 
 class ReservationService
@@ -389,11 +391,10 @@ class ReservationService
 
         $this->validateBusinessHours($startTime, $endTime, $settings);
 
-        if (Carbon::parse($startTime)->minute % $settings->time_slot_interval_minutes !== 0) {
-            throw ValidationException::withMessages([
-                'start_time' => ["La hora de inicio debe estar alineada a intervalos de {$settings->time_slot_interval_minutes} minutos."],
-            ]);
-        }
+        Validator::make(
+            ['start_time' => $startTime],
+            ['start_time' => [new AlignedToInterval($settings->time_slot_interval_minutes)]],
+        )->validate();
     }
 
     private function validateBusinessHours(string $startTime, string $endTime, RestaurantSetting $settings): void

--- a/tests/Unit/Rules/AlignedToIntervalTest.php
+++ b/tests/Unit/Rules/AlignedToIntervalTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Unit\Rules;
+
+use App\Rules\AlignedToInterval;
+use PHPUnit\Framework\TestCase;
+
+class AlignedToIntervalTest extends TestCase
+{
+    private function fails(int $interval, string $value): bool
+    {
+        $failed = false;
+        $rule = new AlignedToInterval($interval);
+        $rule->validate('time', $value, function () use (&$failed) {
+            $failed = true;
+        });
+
+        return $failed;
+    }
+
+    public function test_passes_when_time_is_aligned_to_30_minute_interval(): void
+    {
+        $this->assertFalse($this->fails(30, '09:00'));
+        $this->assertFalse($this->fails(30, '09:30'));
+        $this->assertFalse($this->fails(30, '13:30:00'));
+    }
+
+    public function test_fails_when_time_is_not_aligned_to_30_minute_interval(): void
+    {
+        $this->assertTrue($this->fails(30, '09:15'));
+        $this->assertTrue($this->fails(30, '09:45'));
+    }
+
+    public function test_passes_when_time_is_aligned_to_60_minute_interval(): void
+    {
+        $this->assertFalse($this->fails(60, '09:00'));
+        $this->assertFalse($this->fails(60, '22:00:00'));
+    }
+
+    public function test_fails_when_time_is_not_aligned_to_60_minute_interval(): void
+    {
+        $this->assertTrue($this->fails(60, '09:30'));
+        $this->assertTrue($this->fails(60, '09:15'));
+    }
+
+    public function test_abstains_when_value_is_empty(): void
+    {
+        $this->assertFalse($this->fails(30, ''));
+    }
+}


### PR DESCRIPTION
## Summary
- Add `App\Rules\AlignedToInterval`, a `ValidationRule` parameterized by the slot interval, validating on total-minutes-from-midnight (handles both `H:i` and `H:i:s`)
- Route `UpdateRestaurantSettingRequest` (`opening_time`, `closing_time`) through the rule, preserving the cross-field check against stored settings
- Route `ReservationService::validateReservationWindow()` (`start_time`) through the rule via `Validator::make`, keeping the same `ValidationException` / field key
- Remove the three inline modulo checks and the implementation drift between layers (total-minutes vs minute-of-hour)

## Test plan
- [x] New unit test `AlignedToIntervalTest` (aligned / not aligned for 30 & 60, `H:i` and `H:i:s`, empty guard)
- [x] `RestaurantSettingTest` green, including interval change that misaligns existing stored times
- [x] `ReservationServiceTest` and `TimeSlotsTest` green
- [x] Full suite green (290 passed, 932 assertions)

Closes #153