### PR TITLE
Read settings through repository in UpdateRestaurantSettingRequest

### DIFF
--- a/app/Http/Requests/UpdateRestaurantSettingRequest.php
+++ b/app/Http/Requests/UpdateRestaurantSettingRequest.php
@@ -2,12 +2,18 @@
 
 namespace App\Http\Requests;
 
+use App\Repositories\RestaurantSettingRepository;
 use App\Rules\AlignedToInterval;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
 class UpdateRestaurantSettingRequest extends FormRequest
 {
+    public function __construct(private RestaurantSettingRepository $repository)
+    {
+        parent::__construct();
+    }
+
     public function authorize(): bool
     {
         return true;
@@ -31,7 +37,7 @@ class UpdateRestaurantSettingRequest extends FormRequest
     {
         return [
             function ($validator) {
-                $settings = $this->existingSettings();
+                $settings = $this->repository->get();
                 $opening = $this->input('opening_time', $settings->opening_time);
                 $closing = $this->input('closing_time', $settings->closing_time);
                 $interval = (int) $this->input('time_slot_interval_minutes', $settings->time_slot_interval_minutes);
@@ -50,10 +56,5 @@ class UpdateRestaurantSettingRequest extends FormRequest
     private function toMinutes(string $time): int
     {
         return (int) substr($time, 0, 2) * 60 + (int) substr($time, 3, 2);
-    }
-
-    private function existingSettings(): \App\Models\RestaurantSetting
-    {
-        return \App\Models\RestaurantSetting::firstOrFail();
     }
 }


### PR DESCRIPTION
## Summary

- Inject `RestaurantSettingRepository` into `UpdateRestaurantSettingRequest` via the constructor
- Replace the direct `RestaurantSetting::firstOrFail()` call in cross-field validation with `RestaurantSettingRepository::get()`
- Remove the now-redundant `existingSettings()` helper; the FormRequest no longer references the Eloquent model directly
- Restores the Repository pattern used consistently across services and jobs (single source of truth for reading settings)
- Error contract unchanged: `get()` also uses `firstOrFail()`, so a missing settings row still yields a 404

## Test plan

- [x] Existing suite stays green (290/290, 932 assertions)
- [x] `RestaurantSettingTest` passes (21/21), including the cross-field validation paths that exercise the changed code (`partial update validates against existing hours`, `update rejects interval change that misaligns existing times`)

Closes #155