### PR TITLE
Containerize backend for Cloud Run deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,46 @@
+# Dependencies (reinstalled inside the image)
+/vendor
+/node_modules
+
+# Local environment and secrets
+.env
+.env.*
+!.env.example
+
+# Version control and CI
+.git
+.gitignore
+.github
+
+# Tests and dev tooling
+/tests
+phpunit.xml
+.phpunit.result.cache
+/.editorconfig
+pint.json
+
+# Local-only infrastructure (s6 service files under /docker are needed at build)
+docker-compose.yml
+/docker/postgres
+
+# Compiled Laravel caches (regenerated inside the image; local copies reference
+# dev-only providers absent from the --no-dev build)
+/bootstrap/cache/*.php
+
+# Build artifacts and logs
+/storage/logs/*
+/storage/framework/cache/data/*
+/storage/framework/sessions/*
+/storage/framework/views/*
+/public/build
+/public/hot
+
+# Editor and OS noise
+/.idea
+/.vscode
+.DS_Store
+
+# Project docs not needed at runtime
+CLAUDE.md
+memory.md
+README.md

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ yarn-error.log
 /.vscode
 /.zed
 .mcp.json
+memory.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+# syntax=docker/dockerfile:1
+
+# Production image for both Cloud Run services:
+#   - web:    default command (nginx serves HTTP on $PORT)
+#   - worker: command overridden to "php artisan queue:work"
+# Both keep nginx listening on $PORT so Cloud Run health checks pass.
+FROM serversideup/php:8.3-fpm-nginx
+
+# PHP extensions required by the app:
+#   - pdo_pgsql: PostgreSQL driver (Neon)
+#   - pcntl:     signal handling for graceful queue worker shutdown (--max-time)
+#   - intl, bcmath: required by Laravel/Filament
+USER root
+RUN install-php-extensions pdo_pgsql pcntl intl bcmath
+USER www-data
+
+# Production runtime behavior (serversideup AUTORUN):
+#   - Regenerate Laravel caches at startup; they depend on env/secrets that
+#     Cloud Run injects at runtime, so they cannot be baked at build time.
+#   - Migrations are disabled here and run via a dedicated Cloud Run Job to
+#     avoid races between concurrent instances.
+ENV AUTORUN_ENABLED=true \
+    AUTORUN_LARAVEL_MIGRATION=false \
+    SSL_MODE=off
+
+WORKDIR /var/www/html
+
+# Install PHP dependencies first for better layer caching. Skip scripts to keep
+# artisan from booting during build (no env/secrets are available yet).
+COPY --chown=www-data:www-data composer.json composer.lock ./
+RUN composer install --no-dev --no-scripts --no-autoloader --prefer-dist --no-interaction
+
+# Copy the application and build the optimized, authoritative autoloader.
+COPY --chown=www-data:www-data . .
+RUN composer dump-autoload --no-dev --optimize --classmap-authoritative --no-scripts
+
+# Publish Filament admin panel assets into public/ for production serving.
+RUN php artisan filament:assets
+
+# Register the supervised queue worker as an s6 service. It runs alongside
+# nginx (so the worker service still answers $PORT for Cloud Run health checks)
+# and only processes the queue when WORKER_ENABLED=true.
+USER root
+COPY docker/s6-rc.d/laravel-worker /etc/s6-overlay/s6-rc.d/laravel-worker
+RUN chmod +x /etc/s6-overlay/s6-rc.d/laravel-worker/run \
+    && touch /etc/s6-overlay/s6-rc.d/user/contents.d/laravel-worker
+USER www-data

--- a/docker/s6-rc.d/laravel-worker/run
+++ b/docker/s6-rc.d/laravel-worker/run
@@ -1,0 +1,15 @@
+#!/command/with-contenv bash
+# Long-running queue worker, supervised by s6 alongside nginx + php-fpm.
+# Enabled only when WORKER_ENABLED=true (the Cloud Run worker service); on the
+# web service it stays idle so a single image serves both roles.
+
+if [ "${WORKER_ENABLED:-false}" != "true" ]; then
+    exec sleep infinity
+fi
+
+exec php /var/www/html/artisan queue:work redis \
+    --queue=default \
+    --tries=3 \
+    --max-time=3600 \
+    --sleep=3 \
+    --backoff=5

--- a/docker/s6-rc.d/laravel-worker/type
+++ b/docker/s6-rc.d/laravel-worker/type
@@ -1,0 +1,1 @@
+longrun


### PR DESCRIPTION
## Summary
- Add a single production image (`serversideup/php:8.3-fpm-nginx`) serving both the web and worker Cloud Run services
- Run the queue worker as a supervised s6 service, enabled via `WORKER_ENABLED` so one image covers both roles
- Install required PHP extensions: `pdo_pgsql`, `pcntl`, `intl`, `bcmath`
- Enable AUTORUN with migrations disabled (run via a dedicated Cloud Run Job to avoid races)
- Build an optimized, classmap-authoritative autoloader and publish Filament assets at build time
- Add `.dockerignore` excluding vendor, env, tests and compiled caches from the build context
- Ignore local `memory.md` from version control

## Test plan
- [x] `docker build -t restaurant-api .` completes successfully (all stages pass)
- [ ] Web service boots and answers HTTP on `$PORT` in Cloud Run
- [ ] Worker service processes the Redis queue when `WORKER_ENABLED=true`
- [ ] Migration Cloud Run Job runs `migrate --force` against Neon

Closes #159