### PR TITLE
fix: rename analytics revenue endpoint to deposits (deposits are not revenue)

### DIFF
--- a/app/Http/Controllers/Admin/AnalyticsController.php
+++ b/app/Http/Controllers/Admin/AnalyticsController.php
@@ -19,11 +19,11 @@ class AnalyticsController extends Controller
         return response()->json(['data' => $this->service->occupancy($filter)]);
     }
 
-    public function revenue(AnalyticsFilterRequest $request): JsonResponse
+    public function deposits(AnalyticsFilterRequest $request): JsonResponse
     {
         $filter = new AnalyticsFilterDTO(...$request->validated());
 
-        return response()->json(['data' => $this->service->revenue($filter)]);
+        return response()->json(['data' => $this->service->deposits($filter)]);
     }
 
     public function topMenuItems(AnalyticsFilterRequest $request): JsonResponse

--- a/app/Repositories/AnalyticsRepository.php
+++ b/app/Repositories/AnalyticsRepository.php
@@ -84,7 +84,7 @@ class AnalyticsRepository
             ->avg('seats_requested') ?? 0);
     }
 
-    public function revenueTotals(AnalyticsFilterDTO $filter): object
+    public function depositTotals(AnalyticsFilterDTO $filter): object
     {
         return DB::table('payments')
             ->join('reservations', 'payments.reservation_id', '=', 'reservations.id')

--- a/app/Services/AnalyticsService.php
+++ b/app/Services/AnalyticsService.php
@@ -41,9 +41,9 @@ class AnalyticsService
         ];
     }
 
-    public function revenue(AnalyticsFilterDTO $filter): array
+    public function deposits(AnalyticsFilterDTO $filter): array
     {
-        $totals = $this->repository->revenueTotals($filter);
+        $totals = $this->repository->depositTotals($filter);
 
         $collected = (float) $totals->total_collected;
         $refunded = (float) $totals->total_refunded;
@@ -51,7 +51,7 @@ class AnalyticsService
         return [
             'total_collected' => round($collected, 2),
             'total_refunded' => round($refunded, 2),
-            'net_revenue' => round($collected - $refunded, 2),
+            'net_deposits' => round($collected - $refunded, 2),
             'total_payments' => (int) $totals->total_payments,
             'average_deposit' => $totals->total_payments > 0
                 ? round($collected / $totals->total_payments, 2)

--- a/routes/api.php
+++ b/routes/api.php
@@ -49,7 +49,7 @@ Route::middleware(['auth:sanctum', 'role:admin'])->prefix('admin')->group(functi
 
     Route::prefix('analytics')->group(function () {
         Route::get('/occupancy', [AnalyticsController::class, 'occupancy']);
-        Route::get('/revenue', [AnalyticsController::class, 'revenue']);
+        Route::get('/deposits', [AnalyticsController::class, 'deposits']);
         Route::get('/top-menu-items', [AnalyticsController::class, 'topMenuItems']);
     });
 });

--- a/tests/Feature/AnalyticsTest.php
+++ b/tests/Feature/AnalyticsTest.php
@@ -27,7 +27,7 @@ class AnalyticsTest extends TestCase
     public function test_unauthenticated_user_cannot_access_analytics(): void
     {
         $this->getJson('/api/admin/analytics/occupancy')->assertStatus(401);
-        $this->getJson('/api/admin/analytics/revenue')->assertStatus(401);
+        $this->getJson('/api/admin/analytics/deposits')->assertStatus(401);
         $this->getJson('/api/admin/analytics/top-menu-items')->assertStatus(401);
     }
 
@@ -36,7 +36,7 @@ class AnalyticsTest extends TestCase
         $client = $this->clientUser();
 
         $this->actingAs($client)->getJson('/api/admin/analytics/occupancy')->assertStatus(403);
-        $this->actingAs($client)->getJson('/api/admin/analytics/revenue')->assertStatus(403);
+        $this->actingAs($client)->getJson('/api/admin/analytics/deposits')->assertStatus(403);
         $this->actingAs($client)->getJson('/api/admin/analytics/top-menu-items')->assertStatus(403);
     }
 
@@ -122,7 +122,7 @@ class AnalyticsTest extends TestCase
 
     // --- Revenue ---
 
-    public function test_revenue_returns_correct_calculations(): void
+    public function test_deposits_returns_correct_calculations(): void
     {
         $reservation1 = Reservation::factory()->confirmed()->create();
         $reservation2 = Reservation::factory()->cancelled()->create([
@@ -144,7 +144,7 @@ class AnalyticsTest extends TestCase
         ]);
 
         $response = $this->actingAs($this->adminUser())
-            ->getJson('/api/admin/analytics/revenue');
+            ->getJson('/api/admin/analytics/deposits');
 
         $response->assertStatus(200);
 
@@ -152,15 +152,15 @@ class AnalyticsTest extends TestCase
 
         $this->assertEquals(50.00, $data['total_collected']);
         $this->assertEquals(15.00, $data['total_refunded']);
-        $this->assertEquals(35.00, $data['net_revenue']);
+        $this->assertEquals(35.00, $data['net_deposits']);
         $this->assertEquals(2, $data['total_payments']);
         $this->assertEquals(25.00, $data['average_deposit']);
     }
 
-    public function test_revenue_with_no_payments_returns_zeros(): void
+    public function test_deposits_with_no_payments_returns_zeros(): void
     {
         $response = $this->actingAs($this->adminUser())
-            ->getJson('/api/admin/analytics/revenue');
+            ->getJson('/api/admin/analytics/deposits');
 
         $response->assertStatus(200);
 
@@ -168,7 +168,7 @@ class AnalyticsTest extends TestCase
 
         $this->assertEquals(0, $data['total_collected']);
         $this->assertEquals(0, $data['total_refunded']);
-        $this->assertEquals(0, $data['net_revenue']);
+        $this->assertEquals(0, $data['net_deposits']);
         $this->assertEquals(0, $data['total_payments']);
         $this->assertEquals(0, $data['average_deposit']);
     }
@@ -265,7 +265,7 @@ class AnalyticsTest extends TestCase
         $this->assertEquals(1, $data['by_status']['confirmed']);
     }
 
-    public function test_date_filter_works_on_revenue_endpoint(): void
+    public function test_date_filter_works_on_deposits_endpoint(): void
     {
         $inRange = Reservation::factory()->confirmed()->create(['date' => '2026-03-15']);
         $outOfRange = Reservation::factory()->confirmed()->create(['date' => '2026-03-01']);
@@ -282,7 +282,7 @@ class AnalyticsTest extends TestCase
         ]);
 
         $response = $this->actingAs($this->adminUser())
-            ->getJson('/api/admin/analytics/revenue?date_from=2026-03-10&date_to=2026-03-20');
+            ->getJson('/api/admin/analytics/deposits?date_from=2026-03-10&date_to=2026-03-20');
 
         $response->assertStatus(200);
 


### PR DESCRIPTION
## Summary
- Rename `GET /admin/analytics/revenue` to `GET /admin/analytics/deposits`
- Rename `AnalyticsService::revenue()` -> `deposits()` and the response key `net_revenue` -> `net_deposits`
- Rename `AnalyticsRepository::revenueTotals()` -> `depositTotals()` (query unchanged)
- Rename `AnalyticsController::revenue()` -> `deposits()`
- Update `AnalyticsTest` accordingly (routes + `net_deposits`)

The endpoint exposed deposit cashflow (`payments.amount`/`refund_amount`) under revenue labels, contradicting the business rule that deposits are not revenue. This is a semantic re-framing: the operational cashflow data is preserved, but it no longer claims to be income. `topItemsByRevenue()` and `revenueByCategory()` are out of scope (already backed by real consumption from `reservation_items`).

## Test plan
- [x] `php artisan test --filter=AnalyticsTest` — 12 passed
- [x] Full suite `php artisan test` — 297 passed, 939 assertions
- [x] Regression grep: no remaining `net_revenue` / `revenueTotals` / `analytics/revenue`

Closes #161