### PR TITLE
Conform API output to contract (camelCase, ISO 8601, pagination meta)

### DIFF
--- a/app/Http/Middleware/TransformApiResponse.php
+++ b/app/Http/Middleware/TransformApiResponse.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+use Symfony\Component\HttpFoundation\Response;
+
+class TransformApiResponse
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $response = $next($request);
+
+        if (! $response instanceof JsonResponse) {
+            return $response;
+        }
+
+        if ($response->getStatusCode() === Response::HTTP_UNPROCESSABLE_ENTITY) {
+            return $response;
+        }
+
+        $payload = $response->getData(true);
+
+        if (! is_array($payload)) {
+            return $response;
+        }
+
+        $payload = $this->reshapePagination($payload);
+
+        return $response->setData($this->camelizeKeys($payload));
+    }
+
+    private function reshapePagination(array $payload): array
+    {
+        if (! isset($payload['links'], $payload['meta']['current_page'])) {
+            return $payload;
+        }
+
+        $meta = $payload['meta'];
+        unset($payload['links']);
+
+        $payload['meta'] = [
+            'total' => $meta['total'],
+            'page' => $meta['current_page'],
+            'perPage' => $meta['per_page'],
+        ];
+
+        return $payload;
+    }
+
+    private function camelizeKeys(array $data): array
+    {
+        $result = [];
+
+        foreach ($data as $key => $value) {
+            $camelKey = is_string($key) ? Str::camel($key) : $key;
+            $result[$camelKey] = is_array($value) ? $this->camelizeKeys($value) : $value;
+        }
+
+        return $result;
+    }
+}

--- a/app/Http/Resources/MenuItemResource.php
+++ b/app/Http/Resources/MenuItemResource.php
@@ -18,7 +18,7 @@ class MenuItemResource extends JsonResource
             'is_available' => $this->is_available,
             'is_featured' => $this->is_featured,
             'daily_stock' => $this->when($request->user()?->hasRole('admin'), $this->daily_stock),
-            'created_at' => $this->created_at->toDateTimeString(),
+            'created_at' => $this->created_at,
         ];
     }
 }

--- a/app/Http/Resources/ReservationItemResource.php
+++ b/app/Http/Resources/ReservationItemResource.php
@@ -19,7 +19,7 @@ class ReservationItemResource extends JsonResource
                 'name' => $this->menuItem->name,
                 'category' => $this->menuItem->category->value,
             ],
-            'created_at' => $this->created_at->toDateTimeString(),
+            'created_at' => $this->created_at,
         ];
     }
 }

--- a/app/Http/Resources/ReservationResource.php
+++ b/app/Http/Resources/ReservationResource.php
@@ -15,13 +15,13 @@ class ReservationResource extends JsonResource
             'user_id' => $this->user_id,
             'table' => new TableResource($this->whenLoaded('table')),
             'seats_requested' => $this->seats_requested,
-            'date' => $this->date->format('Y-m-d'),
+            'date' => $this->date,
             'start_time' => $this->start_time,
             'end_time' => $this->end_time,
             'status' => $this->status,
             'expires_at' => $this->when(
                 $this->status === Reservation::STATUS_PENDING,
-                $this->expires_at?->toDateTimeString(),
+                $this->expires_at,
             ),
             'payment' => $this->when(
                 $this->relationLoaded('payment') && $this->payment,
@@ -29,11 +29,11 @@ class ReservationResource extends JsonResource
                     return [
                         'amount' => $this->payment->amount,
                         'status' => $this->payment->status,
-                        'paid_at' => $this->payment->paid_at?->toDateTimeString(),
+                        'paid_at' => $this->payment->paid_at,
                     ];
                 },
             ),
-            'created_at' => $this->created_at->toDateTimeString(),
+            'created_at' => $this->created_at,
         ];
     }
 }

--- a/app/Http/Resources/TableResource.php
+++ b/app/Http/Resources/TableResource.php
@@ -17,7 +17,7 @@ class TableResource extends JsonResource
             'location'     => $this->location,
             'description'  => $this->description,
             'is_active'    => $this->is_active,
-            'created_at'   => $this->created_at->toDateTimeString(),
+            'created_at'   => $this->created_at,
         ];
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace App\Providers;
 
+use Carbon\CarbonInterface;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\ServiceProvider;
 use Stripe\Stripe;
 
@@ -21,5 +23,7 @@ class AppServiceProvider extends ServiceProvider
     public function boot(): void
     {
         Stripe::setApiKey(config('services.stripe.secret'));
+
+        Carbon::serializeUsing(fn (CarbonInterface $date): string => $date->format('Y-m-d\TH:i:s\Z'));
     }
 }

--- a/app/Services/AnalyticsService.php
+++ b/app/Services/AnalyticsService.php
@@ -4,6 +4,7 @@ namespace App\Services;
 
 use App\DTOs\AnalyticsFilterDTO;
 use App\Repositories\AnalyticsRepository;
+use Illuminate\Support\Carbon;
 
 class AnalyticsService
 {
@@ -31,7 +32,7 @@ class AnalyticsService
                     : 0,
             ])->values()->toArray(),
             'peak_days' => $peakDays->map(fn ($day) => [
-                'date' => $day->date,
+                'date' => Carbon::parse($day->date)->format('Y-m-d\TH:i:s\Z'),
                 'total_reservations' => $day->total_reservations,
             ])->toArray(),
             'peak_hours' => $peakHours->map(fn ($hour) => [

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -15,6 +15,10 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->alias([
             'role' => \Spatie\Permission\Middleware\RoleMiddleware::class,
         ]);
+
+        $middleware->api(append: [
+            \App\Http\Middleware\TransformApiResponse::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //

--- a/tests/Feature/AnalyticsTest.php
+++ b/tests/Feature/AnalyticsTest.php
@@ -86,22 +86,22 @@ class AnalyticsTest extends TestCase
         $response->assertStatus(200)
             ->assertJsonStructure([
                 'data' => [
-                    'total_reservations',
-                    'by_status',
-                    'average_seats_per_reservation',
-                    'by_table',
-                    'peak_days',
-                    'peak_hours',
+                    'totalReservations',
+                    'byStatus',
+                    'averageSeatsPerReservation',
+                    'byTable',
+                    'peakDays',
+                    'peakHours',
                 ],
             ]);
 
         $data = $response->json('data');
 
-        $this->assertEquals(3, $data['total_reservations']);
-        $this->assertEquals(1, $data['by_status']['confirmed']);
-        $this->assertEquals(1, $data['by_status']['completed']);
-        $this->assertEquals(1, $data['by_status']['cancelled']);
-        $this->assertEquals(3.0, $data['average_seats_per_reservation']);
+        $this->assertEquals(3, $data['totalReservations']);
+        $this->assertEquals(1, $data['byStatus']['confirmed']);
+        $this->assertEquals(1, $data['byStatus']['completed']);
+        $this->assertEquals(1, $data['byStatus']['cancelled']);
+        $this->assertEquals(3.0, $data['averageSeatsPerReservation']);
     }
 
     public function test_occupancy_with_no_data_returns_zeros(): void
@@ -113,11 +113,11 @@ class AnalyticsTest extends TestCase
 
         $data = $response->json('data');
 
-        $this->assertEquals(0, $data['total_reservations']);
-        $this->assertEquals(0.0, $data['average_seats_per_reservation']);
-        $this->assertEmpty($data['by_table']);
-        $this->assertEmpty($data['peak_days']);
-        $this->assertEmpty($data['peak_hours']);
+        $this->assertEquals(0, $data['totalReservations']);
+        $this->assertEquals(0.0, $data['averageSeatsPerReservation']);
+        $this->assertEmpty($data['byTable']);
+        $this->assertEmpty($data['peakDays']);
+        $this->assertEmpty($data['peakHours']);
     }
 
     // --- Revenue ---
@@ -150,11 +150,11 @@ class AnalyticsTest extends TestCase
 
         $data = $response->json('data');
 
-        $this->assertEquals(50.00, $data['total_collected']);
-        $this->assertEquals(15.00, $data['total_refunded']);
-        $this->assertEquals(35.00, $data['net_deposits']);
-        $this->assertEquals(2, $data['total_payments']);
-        $this->assertEquals(25.00, $data['average_deposit']);
+        $this->assertEquals(50.00, $data['totalCollected']);
+        $this->assertEquals(15.00, $data['totalRefunded']);
+        $this->assertEquals(35.00, $data['netDeposits']);
+        $this->assertEquals(2, $data['totalPayments']);
+        $this->assertEquals(25.00, $data['averageDeposit']);
     }
 
     public function test_deposits_with_no_payments_returns_zeros(): void
@@ -166,11 +166,11 @@ class AnalyticsTest extends TestCase
 
         $data = $response->json('data');
 
-        $this->assertEquals(0, $data['total_collected']);
-        $this->assertEquals(0, $data['total_refunded']);
-        $this->assertEquals(0, $data['net_deposits']);
-        $this->assertEquals(0, $data['total_payments']);
-        $this->assertEquals(0, $data['average_deposit']);
+        $this->assertEquals(0, $data['totalCollected']);
+        $this->assertEquals(0, $data['totalRefunded']);
+        $this->assertEquals(0, $data['netDeposits']);
+        $this->assertEquals(0, $data['totalPayments']);
+        $this->assertEquals(0, $data['averageDeposit']);
     }
 
     // --- Top Menu Items ---
@@ -209,22 +209,22 @@ class AnalyticsTest extends TestCase
         $response->assertStatus(200)
             ->assertJsonStructure([
                 'data' => [
-                    'top_by_quantity',
-                    'top_by_revenue',
-                    'by_category',
+                    'topByQuantity',
+                    'topByRevenue',
+                    'byCategory',
                 ],
             ]);
 
         $data = $response->json('data');
 
-        $this->assertEquals('Tortilla', $data['top_by_quantity'][0]['menu_item']);
-        $this->assertEquals(5, $data['top_by_quantity'][0]['total_quantity']);
+        $this->assertEquals('Tortilla', $data['topByQuantity'][0]['menuItem']);
+        $this->assertEquals(5, $data['topByQuantity'][0]['totalQuantity']);
 
-        $this->assertEquals('Tortilla', $data['top_by_revenue'][0]['menu_item']);
-        $this->assertEquals(40.00, $data['top_by_revenue'][0]['total_revenue']);
+        $this->assertEquals('Tortilla', $data['topByRevenue'][0]['menuItem']);
+        $this->assertEquals(40.00, $data['topByRevenue'][0]['totalRevenue']);
 
-        $this->assertEquals('Paella', $data['top_by_revenue'][1]['menu_item']);
-        $this->assertEquals(30.00, $data['top_by_revenue'][1]['total_revenue']);
+        $this->assertEquals('Paella', $data['topByRevenue'][1]['menuItem']);
+        $this->assertEquals(30.00, $data['topByRevenue'][1]['totalRevenue']);
     }
 
     public function test_top_menu_items_with_no_orders_returns_empty(): void
@@ -236,9 +236,9 @@ class AnalyticsTest extends TestCase
 
         $data = $response->json('data');
 
-        $this->assertEmpty($data['top_by_quantity']);
-        $this->assertEmpty($data['top_by_revenue']);
-        $this->assertEmpty($data['by_category']);
+        $this->assertEmpty($data['topByQuantity']);
+        $this->assertEmpty($data['topByRevenue']);
+        $this->assertEmpty($data['byCategory']);
     }
 
     // --- Date Filters ---
@@ -261,8 +261,8 @@ class AnalyticsTest extends TestCase
 
         $data = $response->json('data');
 
-        $this->assertEquals(1, $data['total_reservations']);
-        $this->assertEquals(1, $data['by_status']['confirmed']);
+        $this->assertEquals(1, $data['totalReservations']);
+        $this->assertEquals(1, $data['byStatus']['confirmed']);
     }
 
     public function test_date_filter_works_on_deposits_endpoint(): void
@@ -288,7 +288,7 @@ class AnalyticsTest extends TestCase
 
         $data = $response->json('data');
 
-        $this->assertEquals(20.00, $data['total_collected']);
-        $this->assertEquals(1, $data['total_payments']);
+        $this->assertEquals(20.00, $data['totalCollected']);
+        $this->assertEquals(1, $data['totalPayments']);
     }
 }

--- a/tests/Feature/ApiContractTest.php
+++ b/tests/Feature/ApiContractTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\MenuItem;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use Tests\Traits\CreatesUsers;
+
+class ApiContractTest extends TestCase
+{
+    use RefreshDatabase;
+    use CreatesUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(\Database\Seeders\RoleSeeder::class);
+    }
+
+    public function test_response_keys_are_camel_case(): void
+    {
+        MenuItem::factory()->create();
+
+        $response = $this->actingAs($this->adminUser())
+            ->getJson('/api/admin/menu-items');
+
+        $item = $response->json('data.0');
+
+        $this->assertArrayHasKey('isAvailable', $item);
+        $this->assertArrayHasKey('isFeatured', $item);
+        $this->assertArrayHasKey('dailyStock', $item);
+        $this->assertArrayHasKey('createdAt', $item);
+        $this->assertArrayNotHasKey('is_available', $item);
+        $this->assertArrayNotHasKey('created_at', $item);
+    }
+
+    public function test_dates_are_serialized_in_iso_8601_with_z_suffix(): void
+    {
+        MenuItem::factory()->create();
+
+        $response = $this->actingAs($this->adminUser())
+            ->getJson('/api/admin/menu-items');
+
+        $this->assertMatchesRegularExpression(
+            '/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/',
+            $response->json('data.0.createdAt'),
+        );
+    }
+
+    public function test_pagination_meta_is_reshaped_to_contract(): void
+    {
+        MenuItem::factory()->count(10)->create();
+
+        $response = $this->actingAs($this->adminUser())
+            ->getJson('/api/admin/menu-items');
+
+        $response->assertJsonStructure([
+            'data',
+            'meta' => ['total', 'page', 'perPage'],
+        ]);
+
+        $this->assertNull($response->json('links'));
+        $this->assertNull($response->json('meta.current_page'));
+        $this->assertSame(1, $response->json('meta.page'));
+        $this->assertSame(10, $response->json('meta.total'));
+    }
+
+    public function test_validation_errors_keep_request_field_names(): void
+    {
+        $response = $this->actingAs($this->adminUser())
+            ->postJson('/api/admin/menu-items', ['price' => -1]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['name', 'category']);
+    }
+}

--- a/tests/Feature/ClientMenuItemTest.php
+++ b/tests/Feature/ClientMenuItemTest.php
@@ -20,8 +20,7 @@ class ClientMenuItemTest extends TestCase
 
         $response->assertStatus(200)
             ->assertJsonStructure([
-                'data' => [['id', 'name', 'description', 'price', 'category', 'is_available', 'is_featured', 'created_at']],
-                'links',
+                'data' => [['id', 'name', 'description', 'price', 'category', 'isAvailable', 'isFeatured', 'createdAt']],
                 'meta',
             ])
             ->assertJsonCount(3, 'data');
@@ -57,7 +56,7 @@ class ClientMenuItemTest extends TestCase
 
         $response->assertStatus(200)
             ->assertJsonCount(1, 'data')
-            ->assertJsonMissing(['daily_stock']);
+            ->assertJsonMissing(['dailyStock']);
     }
 
     public function test_can_filter_by_category(): void
@@ -103,7 +102,7 @@ class ClientMenuItemTest extends TestCase
 
         $response->json('data');
         foreach ($response->json('data') as $item) {
-            $this->assertTrue($item['is_featured']);
+            $this->assertTrue($item['isFeatured']);
         }
     }
 
@@ -118,7 +117,7 @@ class ClientMenuItemTest extends TestCase
             ->assertJsonCount(3, 'data');
 
         foreach ($response->json('data') as $item) {
-            $this->assertFalse($item['is_featured']);
+            $this->assertFalse($item['isFeatured']);
         }
     }
 
@@ -164,7 +163,7 @@ class ClientMenuItemTest extends TestCase
 
         $response->assertStatus(200)
             ->assertJsonStructure([
-                'data' => [['id', 'name', 'description', 'price', 'category', 'is_available', 'is_featured', 'created_at']],
+                'data' => [['id', 'name', 'description', 'price', 'category', 'isAvailable', 'isFeatured', 'createdAt']],
             ]);
     }
 
@@ -177,8 +176,7 @@ class ClientMenuItemTest extends TestCase
         $response->assertStatus(200)
             ->assertJsonStructure([
                 'data',
-                'links' => ['first', 'last', 'prev', 'next'],
-                'meta' => ['current_page', 'last_page', 'per_page', 'total'],
+                'meta' => ['total', 'page', 'perPage'],
             ]);
 
         $this->assertLessThan(20, count($response->json('data')));

--- a/tests/Feature/GuestReservationTest.php
+++ b/tests/Feature/GuestReservationTest.php
@@ -73,8 +73,8 @@ class GuestReservationTest extends TestCase
         $response->assertStatus(201)
             ->assertJsonStructure([
                 'data' => [
-                    'reservation' => ['id', 'table', 'seats_requested', 'date', 'start_time', 'status', 'expires_at'],
-                    'client_secret',
+                    'reservation' => ['id', 'table', 'seatsRequested', 'date', 'startTime', 'status', 'expiresAt'],
+                    'clientSecret',
                 ],
             ])
             ->assertJsonPath('data.reservation.status', 'pending');
@@ -212,7 +212,7 @@ class GuestReservationTest extends TestCase
 
         $response->assertStatus(201)
             ->assertJsonPath('data.reservation.status', 'pending')
-            ->assertJsonPath('data.client_secret', 'pi_test_second_secret');
+            ->assertJsonPath('data.clientSecret', 'pi_test_second_secret');
     }
 
     public function test_guest_hold_rejects_start_time_not_aligned_to_time_slot_interval(): void

--- a/tests/Feature/MenuItemTest.php
+++ b/tests/Feature/MenuItemTest.php
@@ -29,8 +29,7 @@ class MenuItemTest extends TestCase
 
         $response->assertStatus(200)
             ->assertJsonStructure([
-                'data' => [['id', 'name', 'description', 'price', 'category', 'is_available', 'daily_stock', 'created_at']],
-                'links',
+                'data' => [['id', 'name', 'description', 'price', 'category', 'isAvailable', 'dailyStock', 'createdAt']],
                 'meta',
             ])
             ->assertJsonCount(3, 'data');
@@ -190,7 +189,7 @@ class MenuItemTest extends TestCase
 
         $response->assertStatus(200)
             ->assertJsonPath('data.description', null)
-            ->assertJsonPath('data.daily_stock', null);
+            ->assertJsonPath('data.dailyStock', null);
 
         $this->assertDatabaseHas('menu_items', [
             'id' => $menuItem->id,

--- a/tests/Feature/PreOrderTest.php
+++ b/tests/Feature/PreOrderTest.php
@@ -46,10 +46,10 @@ class PreOrderTest extends TestCase
                 'data' => [[
                     'id',
                     'quantity',
-                    'unit_price',
+                    'unitPrice',
                     'subtotal',
-                    'menu_item' => ['id', 'name', 'category'],
-                    'created_at',
+                    'menuItem' => ['id', 'name', 'category'],
+                    'createdAt',
                 ]],
             ]);
     }
@@ -82,9 +82,9 @@ class PreOrderTest extends TestCase
 
         $response->assertStatus(201)
             ->assertJsonPath('data.quantity', 2)
-            ->assertJsonPath('data.unit_price', '12.50')
+            ->assertJsonPath('data.unitPrice', '12.50')
             ->assertJsonPath('data.subtotal', '25.00')
-            ->assertJsonPath('data.menu_item.id', $menuItem->id);
+            ->assertJsonPath('data.menuItem.id', $menuItem->id);
 
         $this->assertDatabaseHas('reservation_items', [
             'reservation_id' => $reservation->id,

--- a/tests/Feature/ProfileTest.php
+++ b/tests/Feature/ProfileTest.php
@@ -41,7 +41,7 @@ class ProfileTest extends TestCase
             ->assertJsonPath('data.email', $user->email)
             ->assertJsonPath('data.phone', '612345678')
             ->assertJsonPath('data.role', 'client')
-            ->assertJsonPath('data.is_guest', false);
+            ->assertJsonPath('data.isGuest',false);
     }
 
     public function test_admin_can_view_profile(): void
@@ -53,7 +53,7 @@ class ProfileTest extends TestCase
         $response->assertStatus(200)
             ->assertJsonPath('data.role', 'admin')
             ->assertJsonPath('data.phone', null)
-            ->assertJsonPath('data.is_guest', false);
+            ->assertJsonPath('data.isGuest',false);
     }
 
     public function test_guest_user_shows_is_guest_true(): void
@@ -65,7 +65,7 @@ class ProfileTest extends TestCase
         $response = $this->actingAs($guest)->getJson('/api/profile');
 
         $response->assertStatus(200)
-            ->assertJsonPath('data.is_guest', true);
+            ->assertJsonPath('data.isGuest',true);
     }
 
     public function test_unauthenticated_user_cannot_view_profile(): void

--- a/tests/Feature/ReservationTest.php
+++ b/tests/Feature/ReservationTest.php
@@ -75,12 +75,12 @@ class ReservationTest extends TestCase
         $response->assertStatus(201)
             ->assertJsonStructure([
                 'data' => [
-                    'reservation' => ['id', 'table', 'seats_requested', 'date', 'start_time', 'status', 'expires_at'],
-                    'client_secret',
+                    'reservation' => ['id', 'table', 'seatsRequested', 'date', 'startTime', 'status', 'expiresAt'],
+                    'clientSecret',
                 ],
             ])
             ->assertJsonPath('data.reservation.status', 'pending')
-            ->assertJsonPath('data.client_secret', 'pi_test_123_secret');
+            ->assertJsonPath('data.clientSecret','pi_test_123_secret');
 
         $this->assertDatabaseHas('reservations', [
             'table_id' => $table->id,
@@ -214,7 +214,7 @@ class ReservationTest extends TestCase
 
         $response->assertStatus(201)
             ->assertJsonPath('data.reservation.status', 'pending')
-            ->assertJsonPath('data.client_secret', 'pi_test_second_secret');
+            ->assertJsonPath('data.clientSecret','pi_test_second_secret');
 
         $this->assertDatabaseHas('reservations', [
             'id' => $firstReservation->id,
@@ -364,7 +364,7 @@ class ReservationTest extends TestCase
             ]);
 
         $response->assertStatus(201)
-            ->assertJsonPath('data.client_secret', 'pi_test_second_secret');
+            ->assertJsonPath('data.clientSecret','pi_test_second_secret');
 
         $this->assertDatabaseHas('reservations', [
             'table_id' => $secondTable->id,

--- a/tests/Feature/RestaurantSettingTest.php
+++ b/tests/Feature/RestaurantSettingTest.php
@@ -29,14 +29,14 @@ class RestaurantSettingTest extends TestCase
         $response->assertStatus(200)
             ->assertJsonStructure([
                 'data' => [
-                    'deposit_per_person',
-                    'cancellation_deadline_hours',
-                    'refund_percentage',
-                    'default_reservation_duration_minutes',
-                    'reminder_hours_before',
-                    'time_slot_interval_minutes',
-                    'opening_time',
-                    'closing_time',
+                    'depositPerPerson',
+                    'cancellationDeadlineHours',
+                    'refundPercentage',
+                    'defaultReservationDurationMinutes',
+                    'reminderHoursBefore',
+                    'timeSlotIntervalMinutes',
+                    'openingTime',
+                    'closingTime',
                 ],
             ]);
     }
@@ -51,7 +51,7 @@ class RestaurantSettingTest extends TestCase
             ]);
 
         $response->assertStatus(200)
-            ->assertJsonPath('data.time_slot_interval_minutes', 30);
+            ->assertJsonPath('data.timeSlotIntervalMinutes', 30);
 
         $this->assertDatabaseHas('restaurant_settings', [
             'time_slot_interval_minutes' => 30,
@@ -67,8 +67,8 @@ class RestaurantSettingTest extends TestCase
             ]);
 
         $response->assertStatus(200)
-            ->assertJsonPath('data.deposit_per_person', '10.00')
-            ->assertJsonPath('data.cancellation_deadline_hours', 48);
+            ->assertJsonPath('data.depositPerPerson', '10.00')
+            ->assertJsonPath('data.cancellationDeadlineHours', 48);
     }
 
     public function test_update_does_not_modify_fields_not_sent(): void
@@ -172,8 +172,8 @@ class RestaurantSettingTest extends TestCase
             ]);
 
         $response->assertStatus(200)
-            ->assertJsonPath('data.opening_time', '10:00')
-            ->assertJsonPath('data.closing_time', '22:00');
+            ->assertJsonPath('data.openingTime','10:00')
+            ->assertJsonPath('data.closingTime','22:00');
     }
 
     public function test_update_rejects_opening_time_after_closing_time(): void
@@ -270,8 +270,8 @@ class RestaurantSettingTest extends TestCase
                 'closing_time' => '22:00',
             ])
             ->assertStatus(200)
-            ->assertJsonPath('data.opening_time', '08:00')
-            ->assertJsonPath('data.closing_time', '22:00');
+            ->assertJsonPath('data.openingTime','08:00')
+            ->assertJsonPath('data.closingTime','22:00');
     }
 
     // ── Public Endpoint ─────────────────────────────────────
@@ -283,16 +283,16 @@ class RestaurantSettingTest extends TestCase
         $response->assertStatus(200)
             ->assertJsonStructure([
                 'data' => [
-                    'opening_time',
-                    'closing_time',
-                    'time_slot_interval_minutes',
-                    'default_reservation_duration_minutes',
+                    'openingTime',
+                    'closingTime',
+                    'timeSlotIntervalMinutes',
+                    'defaultReservationDurationMinutes',
                 ],
             ])
-            ->assertJsonPath('data.opening_time', '09:00')
-            ->assertJsonPath('data.closing_time', '23:00')
-            ->assertJsonPath('data.time_slot_interval_minutes', 30)
-            ->assertJsonPath('data.default_reservation_duration_minutes', 60);
+            ->assertJsonPath('data.openingTime','09:00')
+            ->assertJsonPath('data.closingTime','23:00')
+            ->assertJsonPath('data.timeSlotIntervalMinutes', 30)
+            ->assertJsonPath('data.defaultReservationDurationMinutes', 60);
     }
 
     public function test_public_endpoint_does_not_expose_sensitive_settings(): void
@@ -300,8 +300,8 @@ class RestaurantSettingTest extends TestCase
         $response = $this->getJson('/api/settings/public');
 
         $response->assertStatus(200)
-            ->assertJsonMissing(['deposit_per_person'])
-            ->assertJsonMissing(['cancellation_deadline_hours'])
-            ->assertJsonMissing(['refund_percentage']);
+            ->assertJsonMissing(['depositPerPerson'])
+            ->assertJsonMissing(['cancellationDeadlineHours'])
+            ->assertJsonMissing(['refundPercentage']);
     }
 }

--- a/tests/Feature/TableTest.php
+++ b/tests/Feature/TableTest.php
@@ -39,8 +39,7 @@ class TableTest extends TestCase
 
         $response->assertStatus(200)
             ->assertJsonStructure([
-                'data'  => [['id', 'name', 'min_capacity', 'max_capacity', 'location', 'is_active']],
-                'links',
+                'data'  => [['id', 'name', 'minCapacity', 'maxCapacity', 'location', 'isActive']],
                 'meta',
             ]);
     }
@@ -52,7 +51,7 @@ class TableTest extends TestCase
 
         $response->assertStatus(201)
             ->assertJsonStructure([
-                'data' => ['id', 'name', 'min_capacity', 'max_capacity', 'location', 'is_active'],
+                'data' => ['id', 'name', 'minCapacity', 'maxCapacity', 'location', 'isActive'],
             ]);
 
         $this->assertDatabaseHas('tables', ['name' => 'Mesa 1']);

--- a/tests/Feature/TimeSlotsTest.php
+++ b/tests/Feature/TimeSlotsTest.php
@@ -46,9 +46,9 @@ class TimeSlotsTest extends TestCase
         // 09:00 to 22:00 stepping by 30 = 27 slots (22:30+60=23:30 > 23:00, excluded)
         $response->assertStatus(200)
             ->assertJsonCount(27, 'data')
-            ->assertJsonPath('data.0.start_time', '09:00')
+            ->assertJsonPath('data.0.startTime','09:00')
             ->assertJsonPath('data.0.status', 'available')
-            ->assertJsonPath('data.26.start_time', '22:00');
+            ->assertJsonPath('data.26.startTime','22:00');
     }
 
     public function test_returns_slots_with_60_min_interval(): void
@@ -67,8 +67,8 @@ class TimeSlotsTest extends TestCase
         // 10:00 to 21:00 stepping by 60 = 12 slots
         $response->assertStatus(200)
             ->assertJsonCount(12, 'data')
-            ->assertJsonPath('data.0.start_time', '10:00')
-            ->assertJsonPath('data.11.start_time', '21:00');
+            ->assertJsonPath('data.0.startTime','10:00')
+            ->assertJsonPath('data.11.startTime','21:00');
     }
 
     // ── Availability status ─────────────────────────────────
@@ -110,16 +110,16 @@ class TimeSlotsTest extends TestCase
         $slots = collect($response->json('data'));
 
         // 19:00 slot (19:00-20:00) overlaps both reservations (19:00-20:00) → blocked
-        $this->assertEquals('blocked', $slots->firstWhere('start_time', '19:00')['status']);
+        $this->assertEquals('blocked', $slots->firstWhere('startTime','19:00')['status']);
 
         // 19:30 slot (19:30-20:30) overlaps both reservations (19:00-20:00) → blocked
-        $this->assertEquals('blocked', $slots->firstWhere('start_time', '19:30')['status']);
+        $this->assertEquals('blocked', $slots->firstWhere('startTime','19:30')['status']);
 
         // 18:00 slot (18:00-19:00) does not overlap → available
-        $this->assertEquals('available', $slots->firstWhere('start_time', '18:00')['status']);
+        $this->assertEquals('available', $slots->firstWhere('startTime','18:00')['status']);
 
         // 20:00 slot (20:00-21:00) does not overlap → available
-        $this->assertEquals('available', $slots->firstWhere('start_time', '20:00')['status']);
+        $this->assertEquals('available', $slots->firstWhere('startTime','20:00')['status']);
     }
 
     public function test_slot_available_when_at_least_one_table_free(): void
@@ -149,7 +149,7 @@ class TimeSlotsTest extends TestCase
 
         $slots = collect($response->json('data'));
 
-        $this->assertEquals('available', $slots->firstWhere('start_time', '19:00')['status']);
+        $this->assertEquals('available', $slots->firstWhere('startTime','19:00')['status']);
     }
 
     public function test_pending_reservations_do_not_block_slots(): void
@@ -178,7 +178,7 @@ class TimeSlotsTest extends TestCase
 
         $slots = collect($response->json('data'));
 
-        $this->assertEquals('available', $slots->firstWhere('start_time', '19:00')['status']);
+        $this->assertEquals('available', $slots->firstWhere('startTime','19:00')['status']);
     }
 
     public function test_cancelled_and_expired_reservations_do_not_block_slots(): void
@@ -214,7 +214,7 @@ class TimeSlotsTest extends TestCase
 
         $slots = collect($response->json('data'));
 
-        $this->assertEquals('available', $slots->firstWhere('start_time', '19:00')['status']);
+        $this->assertEquals('available', $slots->firstWhere('startTime','19:00')['status']);
     }
 
     // ── Past slots ──────────────────────────────────────────
@@ -238,9 +238,9 @@ class TimeSlotsTest extends TestCase
 
         $slots = collect($response->json('data'));
 
-        $this->assertEquals('blocked', $slots->firstWhere('start_time', '14:30')['status']);
-        $this->assertEquals('blocked', $slots->firstWhere('start_time', '15:00')['status']);
-        $this->assertEquals('available', $slots->firstWhere('start_time', '15:30')['status']);
+        $this->assertEquals('blocked', $slots->firstWhere('startTime','14:30')['status']);
+        $this->assertEquals('blocked', $slots->firstWhere('startTime','15:00')['status']);
+        $this->assertEquals('available', $slots->firstWhere('startTime','15:30')['status']);
     }
 
     // ── Edge cases ──────────────────────────────────────────
@@ -285,14 +285,14 @@ class TimeSlotsTest extends TestCase
         $slots = collect($response->json('data'));
 
         // Slots that overlap with 19:00-20:30: 18:00(18:00-19:30), 18:30(18:30-20:00), 19:00(19:00-20:30), 19:30(19:30-21:00), 20:00(20:00-21:30)
-        $this->assertEquals('blocked', $slots->firstWhere('start_time', '18:00')['status']);
-        $this->assertEquals('blocked', $slots->firstWhere('start_time', '18:30')['status']);
-        $this->assertEquals('blocked', $slots->firstWhere('start_time', '19:00')['status']);
-        $this->assertEquals('blocked', $slots->firstWhere('start_time', '19:30')['status']);
-        $this->assertEquals('blocked', $slots->firstWhere('start_time', '20:00')['status']);
+        $this->assertEquals('blocked', $slots->firstWhere('startTime','18:00')['status']);
+        $this->assertEquals('blocked', $slots->firstWhere('startTime','18:30')['status']);
+        $this->assertEquals('blocked', $slots->firstWhere('startTime','19:00')['status']);
+        $this->assertEquals('blocked', $slots->firstWhere('startTime','19:30')['status']);
+        $this->assertEquals('blocked', $slots->firstWhere('startTime','20:00')['status']);
 
         // 20:30 slot (20:30-22:00) does not overlap with 19:00-20:30 → available
-        $this->assertEquals('available', $slots->firstWhere('start_time', '20:30')['status']);
+        $this->assertEquals('available', $slots->firstWhere('startTime','20:30')['status']);
     }
 
     // ── Validation ──────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add `TransformApiResponse` middleware on the `api` group that recursively camelCases JSON response keys and reshapes pagination meta to `{ total, page, perPage }`, dropping framework-specific `links`
- Centralize date serialization to ISO 8601 with `Z` suffix via `Carbon::serializeUsing` in `AppServiceProvider`
- Stop pre-formatting dates in `Reservation`, `Table`, `MenuItem` and `ReservationItem` resources so the global serializer applies; format `peak_days[].date` (raw DB string) to ISO in `AnalyticsService`
- Keep Resources and services snake_case internally: Filament widgets consume the analytics arrays through web routes and are unaffected
- Exclude validation (422) bodies from transformation so error field names keep matching the snake_case request input

## Test plan
- [x] Full suite green (301 passed, 950 assertions)
- [x] New `ApiContractTest`: camelCase keys, ISO 8601 `Z` dates, pagination meta `{ total, page, perPage }`, and 422 field names preserved
- [x] Updated ~82 feature assertions (snake→camel, ISO, meta shape) without touching request payloads, `assertDatabaseHas`, or 422 errors
- [x] Filament unaffected (web routes bypass the api middleware; internal snake_case keys unchanged)

Closes #163