### PR TITLE
Make cancellation refund resilient with retry job and refund states

### DIFF
--- a/app/Jobs/RefundReservationPaymentJob.php
+++ b/app/Jobs/RefundReservationPaymentJob.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Payment;
+use App\Models\Reservation;
+use App\Notifications\ReservationCancelledNotification;
+use App\Repositories\PaymentRepository;
+use App\Repositories\ReservationRepository;
+use App\Services\PaymentService;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+class RefundReservationPaymentJob implements ShouldQueue
+{
+    use Queueable;
+
+    public int $tries = 5;
+
+    public function __construct(private int $reservationId) {}
+
+    public function backoff(): array
+    {
+        return [60, 300, 900, 3600];
+    }
+
+    public function handle(ReservationRepository $reservationRepository, PaymentService $paymentService): void
+    {
+        $refundAmount = DB::transaction(function () use ($reservationRepository) {
+            $reservation = $reservationRepository->lockById($this->reservationId);
+
+            if (! $reservation || $reservation->status !== Reservation::STATUS_CANCELLED) {
+                return null;
+            }
+
+            $payment = $reservation->payment;
+
+            if (! $payment || $payment->status !== Payment::STATUS_REFUND_PENDING) {
+                return null;
+            }
+
+            return (float) $payment->refund_amount;
+        });
+
+        if ($refundAmount === null) {
+            return;
+        }
+
+        $reservation = $reservationRepository->find($this->reservationId);
+
+        $paymentService->refund($reservation->payment, $refundAmount);
+
+        $reservation->user?->notify(new ReservationCancelledNotification($reservation, $refundAmount));
+    }
+
+    public function failed(Throwable $exception): void
+    {
+        $reservationRepository = app(ReservationRepository::class);
+        $reservation = $reservationRepository->find($this->reservationId);
+
+        if (! $reservation) {
+            return;
+        }
+
+        $payment = $reservation->payment;
+
+        if ($payment && $payment->status === Payment::STATUS_REFUND_PENDING) {
+            app(PaymentRepository::class)->update($payment, [
+                'status' => Payment::STATUS_REFUND_FAILED,
+            ]);
+        }
+
+        Log::error('Refund permanently failed on reservation cancellation', [
+            'reservation_id' => $this->reservationId,
+            'payment_id' => $payment?->id,
+            'gateway_id' => $payment?->payment_gateway_id,
+            'amount' => $payment?->refund_amount,
+            'exception' => $exception->getMessage(),
+        ]);
+
+        $reservation->user?->notify(new ReservationCancelledNotification($reservation, null));
+    }
+}

--- a/app/Models/Payment.php
+++ b/app/Models/Payment.php
@@ -9,11 +9,20 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 class Payment extends Model
 {
     use HasFactory;
+
     public const STATUS_PENDING = 'pending';
+
     public const STATUS_SUCCEEDED = 'succeeded';
+
     public const STATUS_FAILED = 'failed';
+
     public const STATUS_REFUNDED = 'refunded';
+
     public const STATUS_PARTIALLY_REFUNDED = 'partially_refunded';
+
+    public const STATUS_REFUND_PENDING = 'refund_pending';
+
+    public const STATUS_REFUND_FAILED = 'refund_failed';
 
     protected $fillable = [
         'reservation_id',

--- a/app/Services/PaymentService.php
+++ b/app/Services/PaymentService.php
@@ -109,6 +109,8 @@ class PaymentService
         Refund::create([
             'payment_intent' => $payment->payment_gateway_id,
             'amount' => $amountInCents,
+        ], [
+            'idempotency_key' => "reservation_{$payment->reservation_id}_refund",
         ]);
 
         $status = $amount >= (float) $payment->amount
@@ -121,5 +123,13 @@ class PaymentService
         ]);
 
         return $payment->fresh();
+    }
+
+    public function markRefundPending(Payment $payment, float $amount): void
+    {
+        $this->paymentRepository->update($payment, [
+            'status' => Payment::STATUS_REFUND_PENDING,
+            'refund_amount' => $amount,
+        ]);
     }
 }

--- a/app/Services/ReservationService.php
+++ b/app/Services/ReservationService.php
@@ -6,13 +6,14 @@ use App\DTOs\AvailableTablesDTO;
 use App\DTOs\HoldReservationDTO;
 use App\DTOs\TimeSlotsDTO;
 use App\Jobs\ExpireReservationJob;
-use App\Notifications\ReservationCancelledNotification;
-use App\Notifications\GuestReservationConfirmedNotification;
-use App\Notifications\ReservationConfirmedNotification;
-use App\Notifications\ReservationPaymentRefundedNotification;
+use App\Jobs\RefundReservationPaymentJob;
 use App\Models\Payment;
 use App\Models\Reservation;
 use App\Models\RestaurantSetting;
+use App\Notifications\GuestReservationConfirmedNotification;
+use App\Notifications\ReservationCancelledNotification;
+use App\Notifications\ReservationConfirmedNotification;
+use App\Notifications\ReservationPaymentRefundedNotification;
 use App\Repositories\ReservationRepository;
 use App\Repositories\RestaurantSettingRepository;
 use App\Repositories\TableRepository;
@@ -193,7 +194,7 @@ class ReservationService
             ]);
         }
 
-        $reservationDateTime = Carbon::parse($reservation->date->format('Y-m-d') . ' ' . $reservation->start_time);
+        $reservationDateTime = Carbon::parse($reservation->date->format('Y-m-d').' '.$reservation->start_time);
 
         $pendingAction = DB::transaction(function () use ($reservation, $reservationDateTime) {
             $this->reservationRepository->updateStatus($reservation, Reservation::STATUS_CANCELLED);
@@ -219,10 +220,10 @@ class ReservationService
                 ? (float) $payment->amount
                 : (float) $payment->amount * $snapshot->refund_percentage / 100;
 
-            return ['action' => 'refund', 'payment' => $payment, 'amount' => $amount];
-        });
+            $this->paymentService->markRefundPending($payment, $amount);
 
-        $refundAmount = null;
+            return ['action' => 'refund'];
+        });
 
         if ($pendingAction['action'] === 'cancel') {
             try {
@@ -237,23 +238,13 @@ class ReservationService
         }
 
         if ($pendingAction['action'] === 'refund') {
-            try {
-                $this->paymentService->refund($pendingAction['payment'], $pendingAction['amount']);
-                $refundAmount = $pendingAction['amount'];
-            } catch (\Exception $e) {
-                Log::error('Failed to refund payment on reservation cancellation', [
-                    'reservation_id' => $reservation->id,
-                    'payment_id' => $pendingAction['payment']->id,
-                    'gateway_id' => $pendingAction['payment']->payment_gateway_id,
-                    'amount' => $pendingAction['amount'],
-                ]);
-            }
+            RefundReservationPaymentJob::dispatch($reservation->id);
         }
 
         $reservation = $reservation->fresh();
 
-        if ($reservation->user) {
-            $reservation->user->notify(new ReservationCancelledNotification($reservation, $refundAmount));
+        if ($pendingAction['action'] !== 'refund' && $reservation->user) {
+            $reservation->user->notify(new ReservationCancelledNotification($reservation, null));
         }
 
         return $reservation;
@@ -340,10 +331,11 @@ class ReservationService
 
             if ($slotEnd > $closing->format('H:i:s')) {
                 $current->addMinutes($interval);
+
                 continue;
             }
 
-            if ($isToday && Carbon::parse($dto->date . ' ' . $slotStart)->lte($now)) {
+            if ($isToday && Carbon::parse($dto->date.' '.$slotStart)->lte($now)) {
                 $status = 'blocked';
             } else {
                 $bookedCount = $reservations
@@ -381,7 +373,7 @@ class ReservationService
         string $endTime,
         RestaurantSetting $settings
     ): void {
-        $reservationDateTime = Carbon::parse($date . ' ' . $startTime);
+        $reservationDateTime = Carbon::parse($date.' '.$startTime);
 
         if ($reservationDateTime->isPast() || Carbon::parse($date)->greaterThan(now()->addWeek())) {
             throw ValidationException::withMessages([

--- a/tests/Feature/Jobs/RefundReservationPaymentJobTest.php
+++ b/tests/Feature/Jobs/RefundReservationPaymentJobTest.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Tests\Feature\Jobs;
+
+use App\Jobs\RefundReservationPaymentJob;
+use App\Models\Payment;
+use App\Models\Reservation;
+use App\Notifications\ReservationCancelledNotification;
+use App\Repositories\ReservationRepository;
+use App\Services\PaymentService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Notification;
+use Mockery;
+use Mockery\MockInterface;
+use Tests\TestCase;
+use Tests\Traits\CreatesUsers;
+
+class RefundReservationPaymentJobTest extends TestCase
+{
+    use CreatesUsers;
+    use RefreshDatabase;
+
+    private PaymentService&MockInterface $paymentServiceMock;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed(\Database\Seeders\RoleSeeder::class);
+        $this->seed(\Database\Seeders\RestaurantSettingSeeder::class);
+
+        $this->paymentServiceMock = Mockery::mock(PaymentService::class);
+        $this->app->instance(PaymentService::class, $this->paymentServiceMock);
+    }
+
+    private function runJob(int $reservationId): void
+    {
+        (new RefundReservationPaymentJob($reservationId))->handle(
+            app(ReservationRepository::class),
+            $this->paymentServiceMock,
+        );
+    }
+
+    public function test_refunds_pending_payment_and_notifies_customer(): void
+    {
+        Notification::fake();
+
+        $client = $this->clientUser();
+        $reservation = Reservation::factory()->cancelled()->create(['user_id' => $client->id]);
+        $payment = Payment::factory()->for($reservation)->create([
+            'status' => Payment::STATUS_REFUND_PENDING,
+            'refund_amount' => 5.00,
+        ]);
+
+        $this->paymentServiceMock
+            ->shouldReceive('refund')
+            ->once()
+            ->with(Mockery::on(fn ($p) => $p->id === $payment->id), 5.00);
+
+        $this->runJob($reservation->id);
+
+        Notification::assertSentToTimes($client, ReservationCancelledNotification::class, 1);
+    }
+
+    public function test_is_noop_when_payment_no_longer_refund_pending(): void
+    {
+        Notification::fake();
+
+        $client = $this->clientUser();
+        $reservation = Reservation::factory()->cancelled()->create(['user_id' => $client->id]);
+        Payment::factory()->for($reservation)->create([
+            'status' => Payment::STATUS_REFUNDED,
+            'refund_amount' => 5.00,
+        ]);
+
+        $this->paymentServiceMock->shouldNotReceive('refund');
+
+        $this->runJob($reservation->id);
+
+        Notification::assertNothingSent();
+    }
+
+    public function test_is_noop_when_reservation_not_cancelled(): void
+    {
+        Notification::fake();
+
+        $client = $this->clientUser();
+        $reservation = Reservation::factory()->confirmed()->create(['user_id' => $client->id]);
+        Payment::factory()->for($reservation)->create([
+            'status' => Payment::STATUS_REFUND_PENDING,
+            'refund_amount' => 5.00,
+        ]);
+
+        $this->paymentServiceMock->shouldNotReceive('refund');
+
+        $this->runJob($reservation->id);
+
+        Notification::assertNothingSent();
+    }
+
+    public function test_failed_marks_payment_refund_failed_logs_and_notifies(): void
+    {
+        Notification::fake();
+
+        $client = $this->clientUser();
+        $reservation = Reservation::factory()->cancelled()->create(['user_id' => $client->id]);
+        $payment = Payment::factory()->for($reservation)->create([
+            'status' => Payment::STATUS_REFUND_PENDING,
+            'refund_amount' => 5.00,
+        ]);
+
+        Log::shouldReceive('error')
+            ->once()
+            ->with('Refund permanently failed on reservation cancellation', Mockery::subset([
+                'reservation_id' => $reservation->id,
+                'payment_id' => $payment->id,
+            ]));
+
+        (new RefundReservationPaymentJob($reservation->id))->failed(new \Exception('Stripe unavailable'));
+
+        $this->assertSame(Payment::STATUS_REFUND_FAILED, $payment->fresh()->status);
+        Notification::assertSentToTimes($client, ReservationCancelledNotification::class, 1);
+    }
+}

--- a/tests/Feature/ReservationNotificationTest.php
+++ b/tests/Feature/ReservationNotificationTest.php
@@ -7,8 +7,8 @@ use App\Jobs\SendReservationRemindersJob;
 use App\Models\Payment;
 use App\Models\Reservation;
 use App\Models\User;
-use App\Notifications\ReservationCancelledNotification;
 use App\Notifications\GuestReservationConfirmedNotification;
+use App\Notifications\ReservationCancelledNotification;
 use App\Notifications\ReservationConfirmedNotification;
 use App\Notifications\ReservationExpiredNotification;
 use App\Notifications\ReservationPaymentRefundedNotification;
@@ -25,8 +25,8 @@ use Tests\Traits\CreatesUsers;
 
 class ReservationNotificationTest extends TestCase
 {
-    use RefreshDatabase;
     use CreatesUsers;
+    use RefreshDatabase;
 
     private PaymentService&MockInterface $paymentServiceMock;
 
@@ -46,7 +46,7 @@ class ReservationNotificationTest extends TestCase
     private function webhookPayload(string $gatewayId): string
     {
         return json_encode([
-            'id' => 'evt_test_' . uniqid(),
+            'id' => 'evt_test_'.uniqid(),
             'type' => 'payment_intent.succeeded',
             'data' => [
                 'object' => [
@@ -82,7 +82,7 @@ class ReservationNotificationTest extends TestCase
 
         $payload = $this->webhookPayload('pi_test_confirm');
 
-        $webhookMock = Mockery::mock('alias:' . Webhook::class);
+        $webhookMock = Mockery::mock('alias:'.Webhook::class);
         $webhookMock->shouldReceive('constructEvent')
             ->once()
             ->andReturn(Event::constructFrom(json_decode($payload, true)));
@@ -121,7 +121,7 @@ class ReservationNotificationTest extends TestCase
 
         $payload = $this->webhookPayload('pi_test_guest_confirm');
 
-        $webhookMock = Mockery::mock('alias:' . Webhook::class);
+        $webhookMock = Mockery::mock('alias:'.Webhook::class);
         $webhookMock->shouldReceive('constructEvent')
             ->once()
             ->andReturn(Event::constructFrom(json_decode($payload, true)));
@@ -161,7 +161,7 @@ class ReservationNotificationTest extends TestCase
 
         $payload = $this->webhookPayload('pi_test_guest_token');
 
-        $webhookMock = Mockery::mock('alias:' . Webhook::class);
+        $webhookMock = Mockery::mock('alias:'.Webhook::class);
         $webhookMock->shouldReceive('constructEvent')
             ->once()
             ->andReturn(Event::constructFrom(json_decode($payload, true)));
@@ -189,6 +189,16 @@ class ReservationNotificationTest extends TestCase
         ]);
 
         Payment::factory()->succeeded()->create(['reservation_id' => $reservation->id]);
+
+        $this->paymentServiceMock
+            ->shouldReceive('markRefundPending')
+            ->once()
+            ->andReturnUsing(function (Payment $payment, float $amount): void {
+                $payment->update([
+                    'status' => Payment::STATUS_REFUND_PENDING,
+                    'refund_amount' => $amount,
+                ]);
+            });
 
         $this->paymentServiceMock
             ->shouldReceive('refund')
@@ -245,7 +255,7 @@ class ReservationNotificationTest extends TestCase
 
         $payload = $this->webhookPayload('pi_test_late');
 
-        $webhookMock = Mockery::mock('alias:' . Webhook::class);
+        $webhookMock = Mockery::mock('alias:'.Webhook::class);
         $webhookMock->shouldReceive('constructEvent')
             ->once()
             ->andReturn(Event::constructFrom(json_decode($payload, true)));
@@ -310,7 +320,7 @@ class ReservationNotificationTest extends TestCase
 
         $reservation->forceFill(['created_at' => now()->subDays(2)])->save();
 
-        $job = new SendReservationRemindersJob();
+        $job = new SendReservationRemindersJob;
         $job->handle(
             app(\App\Repositories\RestaurantSettingRepository::class),
             app(\App\Repositories\ReservationRepository::class),
@@ -332,7 +342,7 @@ class ReservationNotificationTest extends TestCase
             'created_at' => now(),
         ]);
 
-        $job = new SendReservationRemindersJob();
+        $job = new SendReservationRemindersJob;
         $job->handle(
             app(\App\Repositories\RestaurantSettingRepository::class),
             app(\App\Repositories\ReservationRepository::class),
@@ -355,7 +365,7 @@ class ReservationNotificationTest extends TestCase
             'reminder_sent_at' => now()->subHour(),
         ]);
 
-        $job = new SendReservationRemindersJob();
+        $job = new SendReservationRemindersJob;
         $job->handle(
             app(\App\Repositories\RestaurantSettingRepository::class),
             app(\App\Repositories\ReservationRepository::class),

--- a/tests/Feature/ReservationTest.php
+++ b/tests/Feature/ReservationTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use App\Jobs\ExpireReservationJob;
+use App\Jobs\RefundReservationPaymentJob;
 use App\Models\Payment;
 use App\Models\Reservation;
 use App\Models\RestaurantSetting;
@@ -18,8 +19,8 @@ use Tests\Traits\CreatesUsers;
 
 class ReservationTest extends TestCase
 {
-    use RefreshDatabase;
     use CreatesUsers;
+    use RefreshDatabase;
 
     private PaymentService&MockInterface $paymentServiceMock;
 
@@ -80,7 +81,7 @@ class ReservationTest extends TestCase
                 ],
             ])
             ->assertJsonPath('data.reservation.status', 'pending')
-            ->assertJsonPath('data.clientSecret','pi_test_123_secret');
+            ->assertJsonPath('data.clientSecret', 'pi_test_123_secret');
 
         $this->assertDatabaseHas('reservations', [
             'table_id' => $table->id,
@@ -214,7 +215,7 @@ class ReservationTest extends TestCase
 
         $response->assertStatus(201)
             ->assertJsonPath('data.reservation.status', 'pending')
-            ->assertJsonPath('data.clientSecret','pi_test_second_secret');
+            ->assertJsonPath('data.clientSecret', 'pi_test_second_secret');
 
         $this->assertDatabaseHas('reservations', [
             'id' => $firstReservation->id,
@@ -364,7 +365,7 @@ class ReservationTest extends TestCase
             ]);
 
         $response->assertStatus(201)
-            ->assertJsonPath('data.clientSecret','pi_test_second_secret');
+            ->assertJsonPath('data.clientSecret', 'pi_test_second_secret');
 
         $this->assertDatabaseHas('reservations', [
             'table_id' => $secondTable->id,
@@ -514,8 +515,10 @@ class ReservationTest extends TestCase
 
     public function test_client_can_cancel_own_confirmed_reservation(): void
     {
+        Queue::fake();
+
         $this->paymentServiceMock
-            ->shouldReceive('refund')
+            ->shouldReceive('markRefundPending')
             ->once();
 
         $client = $this->clientUser();
@@ -535,6 +538,8 @@ class ReservationTest extends TestCase
             'id' => $reservation->id,
             'status' => 'cancelled',
         ]);
+
+        Queue::assertPushed(RefundReservationPaymentJob::class);
     }
 
     public function test_cancel_pending_reservation_without_payment(): void
@@ -701,33 +706,38 @@ class ReservationTest extends TestCase
         $this->assertDatabaseCount('cancellation_policy_snapshots', 0);
     }
 
-    public function test_cancel_cancels_reservation_and_logs_error_when_stripe_refund_fails(): void
+    public function test_cancel_marks_payment_refund_pending_and_dispatches_refund_job(): void
     {
-        $this->paymentServiceMock
-            ->shouldReceive('refund')
-            ->once()
-            ->andThrow(new \Exception('Stripe refund error'));
+        Queue::fake();
 
-        \Illuminate\Support\Facades\Log::shouldReceive('error')
+        $this->paymentServiceMock
+            ->shouldReceive('markRefundPending')
             ->once()
-            ->with('Failed to refund payment on reservation cancellation', Mockery::type('array'));
+            ->andReturnUsing(function (Payment $payment, float $amount): void {
+                $payment->update([
+                    'status' => Payment::STATUS_REFUND_PENDING,
+                    'refund_amount' => $amount,
+                ]);
+            });
 
         $client = $this->clientUser();
         $reservation = Reservation::factory()->withCancellationPolicy()->create([
             'user_id' => $client->id,
         ]);
 
-        Payment::factory()->succeeded()->create(['reservation_id' => $reservation->id]);
+        $payment = Payment::factory()->succeeded()->create(['reservation_id' => $reservation->id]);
 
         $response = $this->actingAs($client)
             ->postJson("/api/reservations/{$reservation->id}/cancel");
 
         $response->assertStatus(200);
 
-        $this->assertDatabaseHas('reservations', [
-            'id' => $reservation->id,
-            'status' => Reservation::STATUS_CANCELLED,
+        $this->assertDatabaseHas('payments', [
+            'id' => $payment->id,
+            'status' => Payment::STATUS_REFUND_PENDING,
         ]);
+
+        Queue::assertPushed(RefundReservationPaymentJob::class);
     }
 
     // ── Business hours validation ───────────────────────────
@@ -770,7 +780,7 @@ class ReservationTest extends TestCase
     {
         RestaurantSetting::first()->update(['opening_time' => '12:00', 'closing_time' => '22:00']);
 
-        $response = $this->getJson('/api/reservations/available-tables?' . http_build_query([
+        $response = $this->getJson('/api/reservations/available-tables?'.http_build_query([
             'date' => now()->addDays(3)->format('Y-m-d'),
             'start_time' => '11:00',
             'seats_requested' => 2,

--- a/tests/Unit/PaymentServiceTest.php
+++ b/tests/Unit/PaymentServiceTest.php
@@ -16,6 +16,7 @@ use Tests\TestCase;
 class PaymentServiceTest extends TestCase
 {
     private PaymentService $service;
+
     private PaymentRepository&MockInterface $paymentRepository;
 
     protected function setUp(): void
@@ -376,6 +377,32 @@ class PaymentServiceTest extends TestCase
         $this->paymentRepository->shouldReceive('update')->once();
 
         $result = $this->service->refund($payment, 10.99);
+
+        $this->assertSame($payment, $result);
+    }
+
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function test_refund_passes_idempotency_key_derived_from_reservation_id(): void
+    {
+        $payment = $this->makePaymentMock(
+            Payment::STATUS_SUCCEEDED,
+            gatewayId: 'pi_idem',
+            amount: 25.50,
+        );
+        $payment->shouldReceive('getAttribute')->with('reservation_id')->andReturn(42);
+
+        $refundMock = Mockery::mock('alias:Stripe\Refund');
+        $refundMock
+            ->shouldReceive('create')
+            ->once()
+            ->withArgs(function (array $params, array $options) {
+                return $options['idempotency_key'] === 'reservation_42_refund';
+            });
+
+        $this->paymentRepository->shouldReceive('update')->once();
+
+        $result = $this->service->refund($payment, 25.50);
 
         $this->assertSame($payment, $result);
     }

--- a/tests/Unit/ReservationServiceTest.php
+++ b/tests/Unit/ReservationServiceTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit;
 
+use App\Jobs\RefundReservationPaymentJob;
 use App\Models\CancellationPolicySnapshot;
 use App\Models\Payment;
 use App\Models\Reservation;
@@ -10,6 +11,7 @@ use App\Repositories\RestaurantSettingRepository;
 use App\Repositories\TableRepository;
 use App\Services\PaymentService;
 use App\Services\ReservationService;
+use Illuminate\Support\Facades\Queue;
 use Illuminate\Validation\ValidationException;
 use Mockery;
 use Mockery\MockInterface;
@@ -18,9 +20,13 @@ use Tests\TestCase;
 class ReservationServiceTest extends TestCase
 {
     private ReservationService $service;
+
     private ReservationRepository&MockInterface $reservationRepository;
+
     private RestaurantSettingRepository&MockInterface $settingRepository;
+
     private TableRepository&MockInterface $tableRepository;
+
     private PaymentService&MockInterface $paymentService;
 
     protected function setUp(): void
@@ -224,8 +230,11 @@ class ReservationServiceTest extends TestCase
 
     public function test_cancel_with_full_refund_when_within_deadline(): void
     {
+        Queue::fake();
+
         /** @var Reservation&MockInterface $reservation */
         $reservation = Mockery::mock(Reservation::class)->makePartial();
+        $reservation->id = 1;
         $reservation->status = Reservation::STATUS_CONFIRMED;
         $reservation->date = new \DateTime(now()->addDays(3)->format('Y-m-d'));
         $reservation->start_time = '20:00:00';
@@ -249,9 +258,11 @@ class ReservationServiceTest extends TestCase
             ->once();
 
         $this->paymentService
-            ->shouldReceive('refund')
+            ->shouldReceive('markRefundPending')
             ->with($payment, 10.00)
             ->once();
+
+        $this->paymentService->shouldNotReceive('refund');
 
         /** @var Reservation&MockInterface $freshReservation */
         $freshReservation = Mockery::mock(Reservation::class)->makePartial();
@@ -261,12 +272,16 @@ class ReservationServiceTest extends TestCase
         $result = $this->service->cancel($reservation);
 
         $this->assertEquals(Reservation::STATUS_CANCELLED, $result->status);
+        Queue::assertPushed(RefundReservationPaymentJob::class);
     }
 
     public function test_cancel_with_partial_refund_when_outside_deadline(): void
     {
+        Queue::fake();
+
         /** @var Reservation&MockInterface $reservation */
         $reservation = Mockery::mock(Reservation::class)->makePartial();
+        $reservation->id = 1;
         $reservation->status = Reservation::STATUS_CONFIRMED;
         $reservation->date = new \DateTime(now()->addHours(5)->format('Y-m-d'));
         $reservation->start_time = now()->addHours(5)->format('H:i:s');
@@ -290,9 +305,11 @@ class ReservationServiceTest extends TestCase
             ->once();
 
         $this->paymentService
-            ->shouldReceive('refund')
+            ->shouldReceive('markRefundPending')
             ->with($payment, 5.00)
             ->once();
+
+        $this->paymentService->shouldNotReceive('refund');
 
         /** @var Reservation&MockInterface $freshReservation */
         $freshReservation = Mockery::mock(Reservation::class)->makePartial();
@@ -302,6 +319,7 @@ class ReservationServiceTest extends TestCase
         $result = $this->service->cancel($reservation);
 
         $this->assertEquals(Reservation::STATUS_CANCELLED, $result->status);
+        Queue::assertPushed(RefundReservationPaymentJob::class);
     }
 
     public function test_cancel_pending_reservation_cancels_payment_intent(): void
@@ -397,60 +415,6 @@ class ReservationServiceTest extends TestCase
         $this->assertEquals(Reservation::STATUS_CANCELLED, $result->status);
     }
 
-    public function test_cancel_logs_error_when_refund_fails(): void
-    {
-        /** @var Reservation&MockInterface $reservation */
-        $reservation = Mockery::mock(Reservation::class)->makePartial();
-        $reservation->id = 1;
-        $reservation->status = Reservation::STATUS_CONFIRMED;
-        $reservation->date = new \DateTime(now()->addDays(3)->format('Y-m-d'));
-        $reservation->start_time = '20:00:00';
-
-        /** @var CancellationPolicySnapshot&MockInterface $snapshot */
-        $snapshot = Mockery::mock(CancellationPolicySnapshot::class)->makePartial();
-        $snapshot->cancellation_deadline_hours = 24;
-        $snapshot->refund_percentage = 50;
-
-        /** @var Payment&MockInterface $payment */
-        $payment = Mockery::mock(Payment::class)->makePartial();
-        $payment->id = 1;
-        $payment->status = Payment::STATUS_SUCCEEDED;
-        $payment->amount = '10.00';
-        $payment->payment_gateway_id = 'pi_test_456';
-
-        $reservation->shouldReceive('getAttribute')->with('payment')->andReturn($payment);
-        $reservation->shouldReceive('getAttribute')->with('cancellationPolicySnapshot')->andReturn($snapshot);
-
-        $this->reservationRepository
-            ->shouldReceive('updateStatus')
-            ->with($reservation, Reservation::STATUS_CANCELLED)
-            ->once();
-
-        $this->paymentService
-            ->shouldReceive('refund')
-            ->with($payment, 10.00)
-            ->once()
-            ->andThrow(new \Exception('Stripe unavailable'));
-
-        /** @var Reservation&MockInterface $freshReservation */
-        $freshReservation = Mockery::mock(Reservation::class)->makePartial();
-        $freshReservation->status = Reservation::STATUS_CANCELLED;
-        $reservation->shouldReceive('fresh')->once()->andReturn($freshReservation);
-
-        \Illuminate\Support\Facades\Log::shouldReceive('error')
-            ->once()
-            ->with('Failed to refund payment on reservation cancellation', Mockery::subset([
-                'reservation_id' => 1,
-                'payment_id' => 1,
-                'gateway_id' => 'pi_test_456',
-                'amount' => 10.00,
-            ]));
-
-        $result = $this->service->cancel($reservation);
-
-        $this->assertEquals(Reservation::STATUS_CANCELLED, $result->status);
-    }
-
     // ── markAsNoShow ─────────────────────────────────────────
 
     public function test_mark_as_no_show_changes_completed_to_no_show(): void
@@ -501,8 +465,11 @@ class ReservationServiceTest extends TestCase
 
     public function test_cancel_same_day_applies_partial_refund(): void
     {
+        Queue::fake();
+
         /** @var Reservation&MockInterface $reservation */
         $reservation = Mockery::mock(Reservation::class)->makePartial();
+        $reservation->id = 1;
         $reservation->status = Reservation::STATUS_CONFIRMED;
         $reservation->date = new \DateTime(now()->format('Y-m-d'));
         $reservation->start_time = now()->addHours(2)->format('H:i:s');
@@ -526,9 +493,11 @@ class ReservationServiceTest extends TestCase
             ->once();
 
         $this->paymentService
-            ->shouldReceive('refund')
+            ->shouldReceive('markRefundPending')
             ->with($payment, 5.00)
             ->once();
+
+        $this->paymentService->shouldNotReceive('refund');
 
         /** @var Reservation&MockInterface $freshReservation */
         $freshReservation = Mockery::mock(Reservation::class)->makePartial();
@@ -538,5 +507,6 @@ class ReservationServiceTest extends TestCase
         $result = $this->service->cancel($reservation);
 
         $this->assertEquals(Reservation::STATUS_CANCELLED, $result->status);
+        Queue::assertPushed(RefundReservationPaymentJob::class);
     }
 }


### PR DESCRIPTION
## Summary
- Move the Stripe refund out of `ReservationService::cancel()` (where it ran outside the transaction and only logged on failure) into a new `RefundReservationPaymentJob` with `tries=5` and exponential backoff.
- Add `Payment` states `refund_pending` / `refund_failed` (string column, no migration) to track the refund lifecycle.
- `cancel()` now marks the payment `refund_pending` with the snapshot amount inside the transaction and dispatches the job; the reservation stays `cancelled`.
- Add a deterministic Stripe idempotency key (`reservation_{id}_refund`) in `PaymentService::refund()` to prevent double refunds across retries.
- On exhausted retries, the job's `failed()` sets `refund_failed`, logs the error for manual admin handling, and still notifies the customer.
- Single customer notification, sent by the job on success (the API already confirms cancellation synchronously).

## Test plan
- [x] `RefundReservationPaymentJobTest`: refunds + notifies on `refund_pending`; no-op when not `refund_pending`; no-op when reservation not cancelled; `failed()` sets `refund_failed`, logs and notifies
- [x] `PaymentServiceTest`: refund passes the deterministic idempotency key; existing refund tests still green
- [x] `ReservationServiceTest`: cancel marks `refund_pending` and dispatches the job (full / partial / same-day)
- [x] `ReservationTest` + `ReservationNotificationTest`: end-to-end cancel marks payment `refund_pending`, dispatches the job, and the customer is notified
- [x] Full suite: 305 passed (964 assertions)

Closes #165