### PR TITLE
Reset daily menu item stock automatically

### DIFF
--- a/app/Filament/Resources/MenuItemResource.php
+++ b/app/Filament/Resources/MenuItemResource.php
@@ -62,10 +62,10 @@ class MenuItemResource extends Resource
                             ->required(),
 
                         TextInput::make('daily_stock')
-                            ->label('Stock diario')
+                            ->label('Cuota diaria')
                             ->numeric()
                             ->minValue(0)
-                            ->helperText('Dejar vacio para stock ilimitado'),
+                            ->helperText('Stock que se repone cada dia. Dejar vacio para stock ilimitado'),
 
                         Textarea::make('description')
                             ->label('Descripcion')
@@ -110,7 +110,12 @@ class MenuItemResource extends Resource
                     }),
 
                 TextColumn::make('daily_stock')
-                    ->label('Stock diario')
+                    ->label('Cuota diaria')
+                    ->sortable()
+                    ->placeholder('Ilimitado'),
+
+                TextColumn::make('stock_remaining')
+                    ->label('Stock restante')
                     ->sortable()
                     ->placeholder('Ilimitado'),
 

--- a/app/Http/Resources/MenuItemResource.php
+++ b/app/Http/Resources/MenuItemResource.php
@@ -18,6 +18,7 @@ class MenuItemResource extends JsonResource
             'is_available' => $this->is_available,
             'is_featured' => $this->is_featured,
             'daily_stock' => $this->when($request->user()?->hasRole('admin'), $this->daily_stock),
+            'stock_remaining' => $this->when($request->user()?->hasRole('admin'), $this->stock_remaining),
             'created_at' => $this->created_at,
         ];
     }

--- a/app/Jobs/ResetDailyStockJob.php
+++ b/app/Jobs/ResetDailyStockJob.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Repositories\MenuItemRepository;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+
+class ResetDailyStockJob implements ShouldQueue
+{
+    use Queueable;
+
+    public function handle(MenuItemRepository $menuItemRepository): void
+    {
+        $menuItemRepository->resetDailyStock();
+    }
+}

--- a/app/Models/MenuItem.php
+++ b/app/Models/MenuItem.php
@@ -20,6 +20,7 @@ class MenuItem extends Model
         'is_available',
         'is_featured',
         'daily_stock',
+        'stock_remaining',
     ];
 
     protected function casts(): array
@@ -59,8 +60,25 @@ class MenuItem extends Model
     public function scopeInStock(Builder $query): Builder
     {
         return $query->where(function (Builder $q) {
-            $q->whereNull('daily_stock')
-                ->orWhere('daily_stock', '>', 0);
+            $q->whereNull('stock_remaining')
+                ->orWhere('stock_remaining', '>', 0);
+        });
+    }
+
+    // Lifecycle
+
+    protected static function booted(): void
+    {
+        static::creating(function (MenuItem $item) {
+            if (! array_key_exists('stock_remaining', $item->getAttributes())) {
+                $item->stock_remaining = $item->daily_stock;
+            }
+        });
+
+        static::updating(function (MenuItem $item) {
+            if ($item->isDirty('daily_stock') && ! $item->isDirty('stock_remaining')) {
+                $item->stock_remaining = $item->daily_stock;
+            }
         });
     }
 }

--- a/app/Repositories/MenuItemRepository.php
+++ b/app/Repositories/MenuItemRepository.php
@@ -5,6 +5,7 @@ namespace App\Repositories;
 use App\Enums\MenuCategory;
 use App\Models\MenuItem;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Facades\DB;
 
 class MenuItemRepository
 {
@@ -68,11 +69,17 @@ class MenuItemRepository
 
     public function decrementStock(MenuItem $menuItem, int $quantity): void
     {
-        $menuItem->decrement('daily_stock', $quantity);
+        $menuItem->decrement('stock_remaining', $quantity);
     }
 
     public function incrementStock(MenuItem $menuItem, int $quantity): void
     {
-        $menuItem->increment('daily_stock', $quantity);
+        $menuItem->increment('stock_remaining', $quantity);
+    }
+
+    public function resetDailyStock(): int
+    {
+        return MenuItem::whereNotNull('daily_stock')
+            ->update(['stock_remaining' => DB::raw('daily_stock')]);
     }
 }

--- a/app/Services/PreOrderService.php
+++ b/app/Services/PreOrderService.php
@@ -43,7 +43,7 @@ class PreOrderService
                 'unit_price' => $menuItem->price,
             ]);
 
-            if ($menuItem->daily_stock !== null) {
+            if ($menuItem->stock_remaining !== null) {
                 $this->menuItemRepository->decrementStock($menuItem, $dto->quantity);
             }
 
@@ -60,7 +60,7 @@ class PreOrderService
         DB::transaction(function () use ($item) {
             $menuItem = $item->menuItem;
 
-            if ($menuItem->daily_stock !== null) {
+            if ($menuItem->stock_remaining !== null) {
                 $this->menuItemRepository->incrementStock($menuItem, $item->quantity);
             }
 
@@ -88,7 +88,7 @@ class PreOrderService
 
     private function ensureMenuItemHasStock(MenuItem $menuItem, int $quantity): void
     {
-        if ($menuItem->daily_stock !== null && $menuItem->daily_stock < $quantity) {
+        if ($menuItem->stock_remaining !== null && $menuItem->stock_remaining < $quantity) {
             throw ValidationException::withMessages([
                 'quantity' => ['No hay suficiente stock disponible para este plato.'],
             ]);

--- a/database/factories/MenuItemFactory.php
+++ b/database/factories/MenuItemFactory.php
@@ -32,7 +32,7 @@ class MenuItemFactory extends Factory
 
     public function withoutStock(): static
     {
-        return $this->state(['daily_stock' => 0]);
+        return $this->state(['daily_stock' => 10, 'stock_remaining' => 0]);
     }
 
     public function unlimitedStock(): static

--- a/database/migrations/2026_06_19_100000_add_stock_remaining_to_menu_items_table.php
+++ b/database/migrations/2026_06_19_100000_add_stock_remaining_to_menu_items_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('menu_items', function (Blueprint $table) {
+            $table->unsignedSmallInteger('stock_remaining')->nullable()->after('daily_stock');
+        });
+
+        DB::table('menu_items')->update(['stock_remaining' => DB::raw('daily_stock')]);
+    }
+
+    public function down(): void
+    {
+        Schema::table('menu_items', function (Blueprint $table) {
+            $table->dropColumn('stock_remaining');
+        });
+    }
+};

--- a/routes/console.php
+++ b/routes/console.php
@@ -1,8 +1,10 @@
 <?php
 
 use App\Jobs\AutoCompleteReservationsJob;
+use App\Jobs\ResetDailyStockJob;
 use App\Jobs\SendReservationRemindersJob;
 use Illuminate\Support\Facades\Schedule;
 
 Schedule::job(new SendReservationRemindersJob())->everyThirtyMinutes();
 Schedule::job(new AutoCompleteReservationsJob())->everyFifteenMinutes();
+Schedule::job(new ResetDailyStockJob())->dailyAt('04:00');

--- a/tests/Feature/MenuItemTest.php
+++ b/tests/Feature/MenuItemTest.php
@@ -29,7 +29,7 @@ class MenuItemTest extends TestCase
 
         $response->assertStatus(200)
             ->assertJsonStructure([
-                'data' => [['id', 'name', 'description', 'price', 'category', 'isAvailable', 'dailyStock', 'createdAt']],
+                'data' => [['id', 'name', 'description', 'price', 'category', 'isAvailable', 'dailyStock', 'stockRemaining', 'createdAt']],
                 'meta',
             ])
             ->assertJsonCount(3, 'data');
@@ -73,9 +73,15 @@ class MenuItemTest extends TestCase
         $response->assertStatus(201)
             ->assertJsonPath('data.name', 'Tortilla de patatas')
             ->assertJsonPath('data.category', 'entrantes')
-            ->assertJsonPath('data.price', '8.50');
+            ->assertJsonPath('data.price', '8.50')
+            ->assertJsonPath('data.dailyStock', 20)
+            ->assertJsonPath('data.stockRemaining', 20);
 
-        $this->assertDatabaseHas('menu_items', ['name' => 'Tortilla de patatas']);
+        $this->assertDatabaseHas('menu_items', [
+            'name' => 'Tortilla de patatas',
+            'daily_stock' => 20,
+            'stock_remaining' => 20,
+        ]);
     }
 
     public function test_menu_item_name_must_be_unique(): void
@@ -189,12 +195,32 @@ class MenuItemTest extends TestCase
 
         $response->assertStatus(200)
             ->assertJsonPath('data.description', null)
-            ->assertJsonPath('data.dailyStock', null);
+            ->assertJsonPath('data.dailyStock', null)
+            ->assertJsonPath('data.stockRemaining', null);
 
         $this->assertDatabaseHas('menu_items', [
             'id' => $menuItem->id,
             'description' => null,
             'daily_stock' => null,
+            'stock_remaining' => null,
+        ]);
+    }
+
+    public function test_updating_quota_resyncs_stock_remaining(): void
+    {
+        $menuItem = MenuItem::factory()->create(['daily_stock' => 10]);
+
+        $response = $this->actingAs($this->adminUser())
+            ->putJson("/api/admin/menu-items/{$menuItem->id}", ['daily_stock' => 30]);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.dailyStock', 30)
+            ->assertJsonPath('data.stockRemaining', 30);
+
+        $this->assertDatabaseHas('menu_items', [
+            'id' => $menuItem->id,
+            'daily_stock' => 30,
+            'stock_remaining' => 30,
         ]);
     }
 

--- a/tests/Feature/PreOrderTest.php
+++ b/tests/Feature/PreOrderTest.php
@@ -94,7 +94,7 @@ class PreOrderTest extends TestCase
         ]);
     }
 
-    public function test_store_decrements_daily_stock(): void
+    public function test_store_decrements_stock_remaining(): void
     {
         $client = $this->clientUser();
         $reservation = Reservation::factory()->confirmed()->create(['user_id' => $client->id]);
@@ -108,7 +108,8 @@ class PreOrderTest extends TestCase
 
         $this->assertDatabaseHas('menu_items', [
             'id' => $menuItem->id,
-            'daily_stock' => 7,
+            'daily_stock' => 10,
+            'stock_remaining' => 7,
         ]);
     }
 
@@ -126,7 +127,7 @@ class PreOrderTest extends TestCase
 
         $this->assertDatabaseHas('menu_items', [
             'id' => $menuItem->id,
-            'daily_stock' => null,
+            'stock_remaining' => null,
         ]);
     }
 
@@ -278,7 +279,7 @@ class PreOrderTest extends TestCase
 
         $this->assertDatabaseHas('menu_items', [
             'id' => $menuItem->id,
-            'daily_stock' => 0,
+            'stock_remaining' => 0,
         ]);
     }
 
@@ -324,7 +325,7 @@ class PreOrderTest extends TestCase
 
         $this->assertDatabaseHas('menu_items', [
             'id' => $menuItem->id,
-            'daily_stock' => 10,
+            'stock_remaining' => 10,
         ]);
     }
 
@@ -345,7 +346,7 @@ class PreOrderTest extends TestCase
 
         $this->assertDatabaseHas('menu_items', [
             'id' => $menuItem->id,
-            'daily_stock' => null,
+            'stock_remaining' => null,
         ]);
     }
 

--- a/tests/Feature/ResetDailyStockJobTest.php
+++ b/tests/Feature/ResetDailyStockJobTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Jobs\ResetDailyStockJob;
+use App\Models\MenuItem;
+use App\Repositories\MenuItemRepository;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ResetDailyStockJobTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function runJob(): void
+    {
+        (new ResetDailyStockJob())->handle(
+            app(MenuItemRepository::class),
+        );
+    }
+
+    public function test_resets_partially_consumed_stock_to_quota(): void
+    {
+        $menuItem = MenuItem::factory()->create([
+            'daily_stock' => 10,
+            'stock_remaining' => 3,
+        ]);
+
+        $this->runJob();
+
+        $this->assertSame(10, $menuItem->fresh()->stock_remaining);
+    }
+
+    public function test_leaves_unlimited_items_untouched(): void
+    {
+        $menuItem = MenuItem::factory()->unlimitedStock()->create();
+
+        $this->runJob();
+
+        $this->assertNull($menuItem->fresh()->stock_remaining);
+    }
+
+    public function test_keeps_full_stock_unchanged(): void
+    {
+        $menuItem = MenuItem::factory()->create(['daily_stock' => 15]);
+
+        $this->runJob();
+
+        $this->assertSame(15, $menuItem->fresh()->stock_remaining);
+    }
+
+    public function test_resets_multiple_items_in_single_run(): void
+    {
+        $first = MenuItem::factory()->create(['daily_stock' => 10, 'stock_remaining' => 0]);
+        $second = MenuItem::factory()->create(['daily_stock' => 20, 'stock_remaining' => 5]);
+
+        $this->runJob();
+
+        $this->assertSame(10, $first->fresh()->stock_remaining);
+        $this->assertSame(20, $second->fresh()->stock_remaining);
+    }
+}


### PR DESCRIPTION
## Summary

- Add nullable `stock_remaining` column to `menu_items`, backfilled from `daily_stock`
- `daily_stock` is now the admin-configured daily quota; `stock_remaining` is the live counter pre-orders decrement/validate against (`PreOrderService`, `MenuItemRepository`, `MenuItem::scopeInStock`)
- Add `ResetDailyStockJob`, scheduled daily at 04:00 UTC, that restores `stock_remaining = daily_stock` for tracked items via a single set-based UPDATE, skipping unlimited (`NULL`) items
- Add a `MenuItem` lifecycle hook: initializes `stock_remaining` from `daily_stock` on create and resyncs it when the quota changes, covering both the API and Filament
- Expose `daily_stock` (quota) and `stock_remaining` to admins in the API resource; relabel Filament to "Cuota diaria" + add a read-only "Stock restante" column

Out of scope (pre-existing): `daily_stock` is a single counter not segmented by reservation date.

## Test plan

- [x] `ResetDailyStockJobTest`: reset partial → quota, unlimited stays null, full unchanged, multiple items in one run
- [x] `PreOrderTest`: stock assertions moved to `stock_remaining`; quota left intact on decrement
- [x] `MenuItemTest`: create initializes `stock_remaining`; quota update resyncs it; API exposes `stockRemaining`
- [x] Full suite green (310 passed)
- [x] Migration runs on dev DB; seeder + lifecycle hook derive `stock_remaining` correctly; reset job verified live (0/30 → 30/30, unlimited untouched)

Closes #167