### PR TITLE
Remove dead expired-reservation queries

### DIFF
--- a/app/Models/Reservation.php
+++ b/app/Models/Reservation.php
@@ -84,12 +84,6 @@ class Reservation extends Model
         return $query->where('status', self::STATUS_CONFIRMED);
     }
 
-    public function scopeExpired(Builder $query): Builder
-    {
-        return $query->where('status', self::STATUS_PENDING)
-            ->where('expires_at', '<=', now());
-    }
-
     public function scopeForTable(Builder $query, int $tableId): Builder
     {
         return $query->where('table_id', $tableId);

--- a/app/Repositories/ReservationRepository.php
+++ b/app/Repositories/ReservationRepository.php
@@ -5,7 +5,6 @@ namespace App\Repositories;
 use App\Models\CancellationPolicySnapshot;
 use App\Models\Reservation;
 use App\Models\Table;
-use Carbon\Carbon;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Eloquent\Collection;
 
@@ -66,11 +65,6 @@ class ReservationRepository
         return Reservation::with(['table', 'payment'])
             ->latest()
             ->paginate($perPage);
-    }
-
-    public function findExpired(): Collection
-    {
-        return Reservation::expired()->get();
     }
 
     public function confirmedReservationsForCapacity(int $seatsRequested, string $date): \Illuminate\Support\Collection


### PR DESCRIPTION
## Summary

- Remove `ReservationRepository::findExpired()`, which had no callers anywhere in the codebase
- Remove `Reservation::scopeExpired()`, whose only caller was `findExpired()`
- Drop the now-unused `Carbon` import left behind in the repository

Expiry is driven by `ExpireReservationJob`, dispatched with a delay at hold time, so no sweep query is needed to find expirable reservations.

The scope was also a naming hazard: it filtered `status = pending AND expires_at <= now` — reservations *due to expire* — while the `expired()` factory state sets `status = STATUS_EXPIRED`. Same name, opposite meaning, waiting for a future caller to filter the wrong set.

Pure deletion: 12 lines removed, 0 added.

## Test plan

- [x] Repo-wide grep (excluding `vendor/`) confirms no residual references to `findExpired`, `scopeExpired` or `Reservation::expired()`
- [x] Full suite green: 312 passed, 982 assertions, with no test file modified
- [x] `expired()` factory state left untouched (used by 6 tests)
- [x] `Collection` import kept in the repository (still used by `findDueForReminder()`); `Builder` kept in the model (still used by the remaining scopes)
- [x] `pint --test` on `ReservationRepository.php` now clean; the remaining `Reservation.php` warning was verified to fail identically on `develop` (pre-existing)

Closes #171